### PR TITLE
Add hypertext links in the article Wrapping C/C++ Library in Swift

### DIFF
--- a/documentation/articles/wrapping-c-cpp-library-in-swift.md
+++ b/documentation/articles/wrapping-c-cpp-library-in-swift.md
@@ -91,7 +91,7 @@ If you're not building a C library alongside your Swift library, you'll need to 
 * ExternalProject
     * Runs at build-time and has most limited configurability, but also isolates the build of the C/C++ library from your build.
     * This is good when coupling between your project and the dependency is low, and the library is unlikely to be installed where your project is expected to run, or when you need some level of configurability over the dependency build.
-    * More details are available at [External Project](https://cmake.org/cmake/help/v3.27/module/ExternalProject.html).
+    * More details are available at [External Project](https://cmake.org/cmake/help/latest/module/ExternalProject.html).
 
 
 ```cmake
@@ -122,13 +122,13 @@ This example downloads zlib v1.3 from GitHub, and builds it. Since we have set a
 * `FetchContent`
     * Runs at configuration time and results in a merged build graph. This is best for pulling in external pieces that are implementation details of your library. Note that because the build graph is merged, variable names and targets need to be namespaced appropriately or they will collide and things may not build as expected.
     * This is good when there is tight coupling between your project and the dependency. Since the build graphs are merged, your project can depend on individual build targets in the dependency, instead of on the project as a whole, which can improve build performance.
-    * More details are available at [FetchContent](https://cmake.org/cmake/help/v3.27/module/FetchContent.html).
+    * More details are available at [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html).
 
 
 * `find_package`
     * Finds the library and header from the sysroot. By default, CMake will look at the root of your OS as the sysroot, but can be isolated to other sysroots for cross-compilation.
     * This option is good for picking up system dependencies from the base system or sysroot, or giving the distributor of your project the option of using a prebuilt project with the use of `<PackageName>_ROOT`.
-    * More details are available at [find_package](https://cmake.org/cmake/help/v3.27/command/find_package.html).
+    * More details are available at [find_package](https://cmake.org/cmake/help/latest/command/find_package.html).
 
  The example of wrapping an existing C library in Swift using CMake will use `find_package`, a custom module-map file, and a Virtual Filesystem (VFS) overlay, as well as a helper layer to migrate parts of the SQLite codebase to something that Swift can import.
 
@@ -157,12 +157,12 @@ Once found, CMake defines the following variables:
 * `SQLite3_VERSION` — The version of sqlite3 found
 * `SQLite3_FOUND` — Used to tell `find_package` that SQLite was found. Note that if we did not mark it as a `REQUIRED` package, we could later check this variable to see if it was found, and fall back on `ExternalProject` to build it separately if it was not.
 
-CMake will also define the `SQLite::SQLite3` build target, which we will use later to make it easier to propagate dependency and search location information through our build graph. Documentation on the SQLite3 package is available here: [FindSQLite3](https://cmake.org/cmake/help/v3.27/module/FindSQLite3.html).
+CMake will also define the `SQLite::SQLite3` build target, which we will use later to make it easier to propagate dependency and search location information through our build graph. Documentation on the SQLite3 package is available here: [FindSQLite3](https://cmake.org/cmake/help/latest/module/FindSQLite3.html).
 
 
 ### Importing SQLite into Swift
 
-Swift can't import header files directly. Some tools like SwiftPM and Xcode can sometimes generate a modulemap for a bridging header, but others, like CMake, do not. Manually writing modulemaps can give you a bit more control over how a C library is imported into Swift. Details on how to write a module map file are available at [Module Map Language](https://clang.llvm.org/docs/Modules.html#module-map-language).
+Swift can't import header files directly. Some tools like SwiftPM and Xcode can sometimes generate a modulemap for a bridging header, but others, like CMake, do not. Manually writing modulemaps can give you a bit more control over how a C library is imported into Swift. Details on how to write a module map file are available on the [Module Map Language](https://clang.llvm.org/docs/Modules.html#module-map-language) specification.
 
 For our example, we only need to expose the `sqlite3.h` header file to Swift.
 

--- a/documentation/articles/wrapping-c-cpp-library-in-swift.md
+++ b/documentation/articles/wrapping-c-cpp-library-in-swift.md
@@ -91,7 +91,7 @@ If you're not building a C library alongside your Swift library, you'll need to 
 * ExternalProject
     * Runs at build-time and has most limited configurability, but also isolates the build of the C/C++ library from your build.
     * This is good when coupling between your project and the dependency is low, and the library is unlikely to be installed where your project is expected to run, or when you need some level of configurability over the dependency build.
-    * More details are available at [https://cmake.org/cmake/help/v3.27/module/ExternalProject.html](https://cmake.org/cmake/help/v3.27/module/ExternalProject.html)
+    * More details are available at [External Project](https://cmake.org/cmake/help/v3.27/module/ExternalProject.html).
 
 
 ```cmake
@@ -122,13 +122,13 @@ This example downloads zlib v1.3 from GitHub, and builds it. Since we have set a
 * `FetchContent`
     * Runs at configuration time and results in a merged build graph. This is best for pulling in external pieces that are implementation details of your library. Note that because the build graph is merged, variable names and targets need to be namespaced appropriately or they will collide and things may not build as expected.
     * This is good when there is tight coupling between your project and the dependency. Since the build graphs are merged, your project can depend on individual build targets in the dependency, instead of on the project as a whole, which can improve build performance.
-    * More details are available at [https://cmake.org/cmake/help/v3.27/module/FetchContent.html](https://cmake.org/cmake/help/v3.27/module/FetchContent.html)
+    * More details are available at [FetchContent](https://cmake.org/cmake/help/v3.27/module/FetchContent.html).
 
 
 * `find_package`
     * Finds the library and header from the sysroot. By default, CMake will look at the root of your OS as the sysroot, but can be isolated to other sysroots for cross-compilation.
     * This option is good for picking up system dependencies from the base system or sysroot, or giving the distributor of your project the option of using a prebuilt project with the use of `<PackageName>_ROOT`.
-    * More details are available at [https://cmake.org/cmake/help/v3.27/command/find_package.html](https://cmake.org/cmake/help/v3.27/command/find_package.html)
+    * More details are available at [find_package](https://cmake.org/cmake/help/v3.27/command/find_package.html).
 
  The example of wrapping an existing C library in Swift using CMake will use `find_package`, a custom module-map file, and a Virtual Filesystem (VFS) overlay, as well as a helper layer to migrate parts of the SQLite codebase to something that Swift can import.
 
@@ -157,12 +157,12 @@ Once found, CMake defines the following variables:
 * `SQLite3_VERSION` — The version of sqlite3 found
 * `SQLite3_FOUND` — Used to tell `find_package` that SQLite was found. Note that if we did not mark it as a `REQUIRED` package, we could later check this variable to see if it was found, and fall back on `ExternalProject` to build it separately if it was not.
 
-CMake will also define the `SQLite::SQLite3` build target, which we will use later to make it easier to propagate dependency and search location information through our build graph. Documentation on the SQLite3 package is available here: [https://cmake.org/cmake/help/v3.27/module/FindSQLite3.html](https://cmake.org/cmake/help/v3.27/module/FindSQLite3.html)
+CMake will also define the `SQLite::SQLite3` build target, which we will use later to make it easier to propagate dependency and search location information through our build graph. Documentation on the SQLite3 package is available here: [FindSQLite3](https://cmake.org/cmake/help/v3.27/module/FindSQLite3.html).
 
 
 ### Importing SQLite into Swift
 
-Swift can't import header files directly. Some tools like SwiftPM and Xcode can sometimes generate a modulemap for a bridging header, but others, like CMake, do not. Manually writing modulemaps can give you a bit more control over how a C library is imported into Swift. Details on how to write a module map file are available at [https://clang.llvm.org/docs/Modules.html#module-map-language](https://clang.llvm.org/docs/Modules.html#module-map-language).
+Swift can't import header files directly. Some tools like SwiftPM and Xcode can sometimes generate a modulemap for a bridging header, but others, like CMake, do not. Manually writing modulemaps can give you a bit more control over how a C library is imported into Swift. Details on how to write a module map file are available at [Module Map Language](https://clang.llvm.org/docs/Modules.html#module-map-language).
 
 For our example, we only need to expose the `sqlite3.h` header file to Swift.
 

--- a/documentation/articles/wrapping-c-cpp-library-in-swift.md
+++ b/documentation/articles/wrapping-c-cpp-library-in-swift.md
@@ -81,7 +81,7 @@ To use custom implementation instead of what comes with the C/C++ library:
 
 ## CMake
 
-This example is geared toward importing a C library into Swift. You'll need to obtain the library, provide a modulemap so that Swift can import it, and then link against it. The mechanics are largely the same for C++, and an example of how to bi-directionally interop with a C++ library built as part of a single project is available in the bidirectional cxx interop project in the [Swift-CMake examples repository](http:// https://github.com/apple/swift-cmake-examples/tree/main/3_bidirectional_cxx_interop).
+This example is geared toward importing a C library into Swift. You'll need to obtain the library, provide a modulemap so that Swift can import it, and then link against it. The mechanics are largely the same for C++, and an example of how to bi-directionally interop with a C++ library built as part of a single project is available in the bidirectional cxx interop project in the [Swift-CMake examples repository](https://github.com/apple/swift-cmake-examples/tree/main/3_bidirectional_cxx_interop).
 
 
 ### Obtaining the library


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
--> 
Added hypertext links in the article [Wrapping C/C++ Library in Swift](https://www.swift.org/documentation/articles/wrapping-c-cpp-library-in-swift.html).

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ --> Improve swift documentation and make it better

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->  URLs in the article that were full-size are formatted as hypertext links

### Result:

<!-- _[After your change, what will change.]_ --> Beautiful Hypertext links 
1. **External Project**
<img width="870" alt="image" src="https://github.com/apple/swift-org-website/assets/45719053/0d8e311a-1351-4bf8-b1ab-92717a2b5a6e">


2. **FetchContent & find_package** 
<img width="880" alt="image" src="https://github.com/apple/swift-org-website/assets/45719053/2be7eb03-e7a8-4a2f-b154-4df32b68f173">


3. **Find SQLite3 & Module Map Language** 
<img width="881" alt="image" src="https://github.com/apple/swift-org-website/assets/45719053/07815803-8182-47e3-acc7-7ac4e25fd6dd">

