### PR TITLE
Fix footer position

### DIFF
--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -8,7 +8,10 @@
 
 html,
 body {
-  height: 100%;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  min-height: 100vh;
 }
 
 body {
@@ -417,7 +420,6 @@ h2.header-with-anchor {
 }
 
 main {
-  margin: auto;
   padding: 4rem 0 0;
 
   .callout {
@@ -469,6 +471,7 @@ footer[role="contentinfo"] {
   color: var(--color-nav-color);
   padding: 20px 30px;
   min-height: 74px;
+  margin-top: auto;
 
   p {
     font-size: 0.625em;


### PR DESCRIPTION
### Motivation:

When the content is the page is short, the footer aligns in too high.

### Modifications:

Added style changes in _screen.scss

### Result:

Before

<img width="1280" alt="Screenshot 2024-06-17 at 10 36 29 AM" src="https://github.com/apple/swift-org-website/assets/59409/16c23b91-261f-420e-b680-6c66ac51d3da">

After

<img width="1281" alt="Screenshot 2024-06-17 at 10 36 04 AM" src="https://github.com/apple/swift-org-website/assets/59409/a671f902-84fc-42a2-8bb8-e73c95fb9ecd">
