### PR TITLE
Repair links to SE dashboard

### DIFF
--- a/_posts/2017-01-18-swift-evolution-status-page.md
+++ b/_posts/2017-01-18-swift-evolution-status-page.md
@@ -6,7 +6,7 @@ title: Swift Evolution Status Page Now Available
 author: krilnon
 ---
 
-We're pleased to announce the release of the new [Swift Evolution](https://apple.github.io/swift-evolution/) status page as a one-stop destination for information about proposed changes to Swift.
+We're pleased to announce the release of the new [Swift Evolution](https://www.swift.org/swift-evolution/) status page as a one-stop destination for information about proposed changes to Swift.
 
 The Swift.org community has wholeheartedly embraced the [Swift Evolution process](https://github.com/swiftlang/swift-evolution/blob/master/process.md)—to date, members have contributed to over 100 proposals. Each new proposal generates a burst of activity in the community.
 

--- a/_posts/2022-07-01-swift-language-updates-from-wwdc22.md
+++ b/_posts/2022-07-01-swift-language-updates-from-wwdc22.md
@@ -10,7 +10,7 @@ author: [fbernutz, hishnash, natpanferova]
 
 > See the [sketchnote in full resolution](/assets/images/swift-language-updates-from-wwdc22-blog/wwdc22-swift-updates-sketch.jpeg)
 
-Swift has evolved significantly during the past year, and we've seen two large updates to the language. [Swift 5.6](https://apple.github.io/swift-evolution/#?version=5.6) was released in March 2022 and introduced major improvements to the type system, concurrency model and Swift ecosystem. It laid the groundwork for further updates in [Swift 5.7](https://apple.github.io/swift-evolution/#?version=5.7), which is included in [beta versions of Xcode 14](https://developer.apple.com/download/applications/) and available on the [Swift.org downloads page](/download/#swift-57-development).
+Swift has evolved significantly during the past year, and we've seen two large updates to the language. [Swift 5.6](https://www.swift.org/swift-evolution/#?version=5.6) was released in March 2022 and introduced major improvements to the type system, concurrency model and Swift ecosystem. It laid the groundwork for further updates in [Swift 5.7](https://www.swift.org/swift-evolution/#?version=5.7), which is included in [beta versions of Xcode 14](https://developer.apple.com/download/applications/) and available on the [Swift.org downloads page](/download/#swift-57-development).
 
 Many Swift updates were rightfully celebrated during WWDC22, with sessions focusing on language changes, tooling improvements, additions to Swift packages and more. The [
 What's new in Swift](https://developer.apple.com/videos/play/wwdc2022/110354/) video provides a great overview of Swift news for the past year. In this post we would like to share our highlights about the Swift ecosystem from WWDC.

--- a/_posts/2022-09-12-swift-5.7-released.md
+++ b/_posts/2022-09-12-swift-5.7-released.md
@@ -74,7 +74,7 @@ If multiple SwiftPM projects are opened in the same Visual Studio Code workspace
 
 ### Swift Package Manager
 
-The following [Swift Evolution](https://github.com/swiftlang/swift-evolution) proposals for SwiftPM were accepted and [implemented in Swift 5.7](https://apple.github.io/swift-evolution/#?version=5.7):
+The following [Swift Evolution](https://github.com/swiftlang/swift-evolution) proposals for SwiftPM were accepted and [implemented in Swift 5.7](https://www.swift.org/swift-evolution/#?version=5.7):
 
 * SE-0292: [Package Registry Service](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0292-package-registry-service.md)
 * SE-0303: [Build tool plugins](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0303-swiftpm-extensible-build-tools.md) and SE-0332: [Command Plugins](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0332-swiftpm-command-plugins.md) which were first introduced in Swift 5.6 have been further refined and made available via Xcode.
@@ -118,7 +118,7 @@ $ yum install swiftlang
 
 ## Swift Evolution Appendix
 
-The following language, standard library, and Swift Package Manager proposals were accepted through the [Swift Evolution](https://github.com/swiftlang/swift-evolution) process and [implemented in Swift 5.7](https://apple.github.io/swift-evolution/#?version=5.7).
+The following language, standard library, and Swift Package Manager proposals were accepted through the [Swift Evolution](https://github.com/swiftlang/swift-evolution) process and [implemented in Swift 5.7](https://www.swift.org/swift-evolution/#?version=5.7).
 
 **Concurrency**
 

--- a/_posts/2023-03-30-swift-5.8-released.md
+++ b/_posts/2023-03-30-swift-5.8-released.md
@@ -119,7 +119,7 @@ Official binaries are [available for download](https://swift.org/download/) from
 
 ## Swift Evolution Appendix
 
-The following language, standard library, and Swift Package Manager proposals were accepted through the [Swift Evolution](https://github.com/swiftlang/swift-evolution) process and [implemented in Swift 5.8](https://apple.github.io/swift-evolution/#?version=5.8).
+The following language, standard library, and Swift Package Manager proposals were accepted through the [Swift Evolution](https://github.com/swiftlang/swift-evolution) process and [implemented in Swift 5.8](https://www.swift.org/swift-evolution/#?version=5.8).
 
 **Language and Standard Library**
 

--- a/_posts/2023-09-18-swift-5.9-released.md
+++ b/_posts/2023-09-18-swift-5.9-released.md
@@ -237,7 +237,7 @@ The Swift community also maintains a number of [translations](/documentation/tsp
 
 ## Swift Evolution Appendix
 
-The following language, standard library, and Swift Package Manager proposals were accepted through the [Swift Evolution](https://github.com/swiftlang/swift-evolution) process and [implemented in Swift 5.9](https://apple.github.io/swift-evolution/#?version=5.9).
+The following language, standard library, and Swift Package Manager proposals were accepted through the [Swift Evolution](https://github.com/swiftlang/swift-evolution) process and [implemented in Swift 5.9](https://www.swift.org/swift-evolution/#?version=5.9).
 
 - SE-0366: [`consume` operator to end the lifetime of a variable binding](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0366-move-function.md)
 - SE-0374: [Add sleep(for:) to Clock](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0374-clock-sleep-for.md)


### PR DESCRIPTION
GitHub Pages shows 404 (file not found) instead of automatically redirecting to the new organization.

### Motivation:

Several blog posts contain links to

https://apple.github.io/swift-evolution/

which doesn't automatically redirect to

https://swiftlang.github.io/swift-evolution/

### Modifications:

Link directly to the SE dashboard at

https://www.swift.org/swift-evolution/

### Result:

Links in blog posts are repaired.
