### PR TITLE
Mentorship Program page improvements

### DIFF
--- a/mentorship/index.md
+++ b/mentorship/index.md
@@ -29,24 +29,24 @@ If the mentee has not contributed to the project before, they will first work wi
 
 The 2024 mentor interest survey submissions are open from June 17th - July 1st. If you are interested in participating as a mentor, please fill out the interest survey [here](https://essentials.applesurveys.com/jfe/form/SV_3CSIxEKQmL1MVhQ).
 
-The mentee interest survey is not an application; but rather it will tell the Diversity in Swift workgroup about your technical interests and learning goals, which will be used to help match you with a suitable mentor. Although the survey won't be evaluated like an application, the workgroup may not be able to match every interested mentee if there aren't enough mentors, or if none of the mentors are equipped to help with your specific learning goals.
+The mentee interest survey is not an application; but rather it will tell the Contributor Experience workgroup about your technical interests and learning goals, which will be used to help match you with a suitable mentor. Although the survey won't be evaluated like an application, the workgroup may not be able to match every interested mentee if there aren't enough mentors, or if none of the mentors are equipped to help with your specific learning goals.
 
 The Swift Mentorship Program is also a leadership opportunity for veteran community members, particularly if they are already an open-source project maintainer or frequent contributor. If you’re passionate about lowering the barrier to entry for new contributors in our community, please consider getting involved as a mentor!
 
 ## Frequently Asked Questions
 
-Participation in the Swift Mentorship program is governed by the [Swift Code of Conduct](/code-of-conduct), and participants agree to the Swift Mentorship Program [terms and conditions](/mentorship-tos/). If you have any questions or concerns throughout the program, please reach out to [@diversity-workgroup](https://forums.swift.org/new-message?groupname=diversity-workgroup) on the Swift Forums.
+Participation in the Swift Mentorship program is governed by the [Swift Code of Conduct](/code-of-conduct), and participants agree to the Swift Mentorship Program [terms and conditions](/mentorship-tos/). If you have any questions or concerns throughout the program, please reach out to [@contributor-experience-workgroup](https://forums.swift.org/new-message?groupname=contributor-experience-workgroup) on the Swift Forums.
 
 <details class="download">
   <summary>How are mentor/mentee pairs selected?</summary>
 
-Mentors and mentees will each fill out an interest survey. The survey is not an application, but rather it tells the Diversity in Swift workgroup about the participant’s interests, experience, learning goals, and more, which will be used to help the workgroup match mentor-mentee pairs. The interest surveys have a parallel set of questions to help evaluate whether the mentor has suitable experience to help the mentee with their learning goals. For example, the mentee questionnaire asks the mentee which specific skills/topics they are interested in working on, and the mentor questionnaire asks which specific skills/topics the mentor has experience with and can help a mentee learn about. A potential mentee will not be matched with a mentor if there are not enough mentors, or if there is not a suitable mentor to help them with their learning goals.
+Mentors and mentees will each fill out an interest survey. The survey is not an application, but rather it tells the Contributor Experience workgroup about the participant’s interests, experience, learning goals, and more, which will be used to help the workgroup match mentor-mentee pairs. The interest surveys have a parallel set of questions to help evaluate whether the mentor has suitable experience to help the mentee with their learning goals. For example, the mentee questionnaire asks the mentee which specific skills/topics they are interested in working on, and the mentor questionnaire asks which specific skills/topics the mentor has experience with and can help a mentee learn about. A potential mentee will not be matched with a mentor if there are not enough mentors, or if there is not a suitable mentor to help them with their learning goals.
 </details>
 
 <details class="download">
   <summary>Are there any necessary qualifications to participate?</summary>
 
-There are no necessary qualifications for mentees — the mentorship program is open to anybody 18 years and older who is willing to learn about Swift! Since this program is designed to encourage and help diverse developers overcome barriers and actively participate in the Swift community, the Diversity in Swift workgroup strongly encourages members of Women in Swift and Black in Swift to participate.
+There are no necessary qualifications for mentees — the mentorship program is open to anybody 18 years and older who is willing to learn about Swift! Since this program is designed to encourage and help diverse developers overcome barriers and actively participate in the Swift community, the Contributor Experience workgroup strongly encourages members of Women in Swift and Black in Swift to participate.
 Mentors must be members of the Swift community (e.g., iOS developers, Swift compiler contributors, etc). Prior experience with mentorship is a plus, but not required.
 </details>
 
@@ -95,11 +95,11 @@ There is no formal evaluation at the end of the mentorship program. However, the
 <details class="download">
   <summary>I’m interested in being a mentor! What should I do?</summary>
 
-Please reach out to <a href="https://forums.swift.org/new-message?groupname=diversity-workgroup">@diversity-workgroup</a> on the Swift Forums if you are interested in participating as a mentor.
+Please fill out the <a href="https://essentials.applesurveys.com/jfe/form/SV_3CSIxEKQmL1MVhQ">Mentor Interest Survey</a> if you are interested in participating as a mentor.
 </details>
 
 <details class="download">
   <summary>I have more questions. What should I do?</summary>
 
-Please reach out to <a href="https://forums.swift.org/new-message?groupname=diversity-workgroup">@diversity-workgroup</a> on the Swift Forums with any additional questions you have!
+Please reach out to <a href="https://forums.swift.org/new-message?groupname=contributor-experience-workgroup">@contributor-experience-workgroup</a> on the Swift Forums with any additional questions you have!
 </details>


### PR DESCRIPTION
### Motivation:

Some of the information on the Mentorship program page is outdated, this is an attempt to rectify that.

### Modifications:

- Replace Diversity in Swift with Contributor Experience workgroup which took over this responsibility;
- Update FAQ about how to become a mentor to point to the ongoing survey.
