### PR TITLE
[cxx-interop] Fix incorrectly referring to "structure" instead of "class"

### DIFF
--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -1588,7 +1588,7 @@ void createMountainRange() {
 Swift classes that are exposed to C++ become C++ classes in the
 generated header. Top-level classes are placed in the C++ `namespace`
 that represents the Swift module. The exposed initializers, methods and
-properties defined inside of the Swift structure become members of the
+properties defined inside of the Swift class become members of the
 C++ class.
 
 The C++ class that represents a Swift class is copyable and movable.


### PR DESCRIPTION
Fix incorrectly referring to "structure" instead of "class" in a section of C++ interoperability documentation.

### Motivation:

Under [Using Swift Classes in C++](https://www.swift.org/documentation/cxx-interop/#using-swift-classes-in-c), the documentation is incorrectly referring to the Swift "structure" instead of "class".

### Modifications:

Replace the Swift "structure" with "class".

### Result:

Before:
> Swift classes that are exposed to C++ become C++ classes in the generated header. Top-level classes are placed in the C++ `namespace` that represents the Swift module. The exposed initializers, methods and properties defined inside of the Swift structure become members of the C++ class.

After:
> Swift classes that are exposed to C++ become C++ classes in the generated header. Top-level classes are placed in the C++ `namespace` that represents the Swift module. The exposed initializers, methods and properties defined inside of the Swift class become members of the C++ class.