### PR TITLE
Fix duplicated grays

### DIFF
--- a/assets/stylesheets/core/_colors.scss
+++ b/assets/stylesheets/core/_colors.scss
@@ -11,6 +11,10 @@ $base-colors: (
     light: rgb(102, 102, 102),
     dark: rgb(204, 204, 204),
   ),
+  figure-gray-tertiary: (
+    light: rgb(102, 102, 102),
+    dark: rgb(176, 176, 176),
+  ),
   figure-blue: (
     light: rgb(51, 102, 255),
     dark: rgb(0, 153, 255),
@@ -27,18 +31,13 @@ $base-colors: (
     light: rgb(240, 240, 240),
     dark: rgb(42, 42, 42),
   ),
-  fill-quaternary: rgb(40, 40, 40),
+  fill-quaternary: (
+    light: rgb(220, 220, 220),
+    dark: rgb(66, 66, 66),
+  ),
   fill-gray-tertiary: (
     light: rgb(240, 240, 240),
     dark: rgb(66, 66, 66),
-  ),
-  figure-gray-tertiary: (
-    light: rgb(102, 102, 102),
-    dark: rgb(176, 176, 176),
-  ),
-  figure-gray-secondary-alt: (
-    light: rgb(102, 102, 102),
-    dark: rgb(176, 176, 176),
   ),
   fill-gray: (
     light: rgb(204, 204, 204),

--- a/assets/stylesheets/core/colors/_dark.scss
+++ b/assets/stylesheets/core/colors/_dark.scss
@@ -6,6 +6,7 @@
   --color-fill: #{dark-color(fill)};
   --color-fill-secondary: #{dark-color(fill-secondary)};
   --color-fill-tertiary: #{dark-color(fill-tertiary)};
+  --color-fill-quaternary: #{dark-color(fill-quaternary)};
   --color-fill-blue: #{dark-color(fill-blue)};
   --color-fill-gray: #{dark-color(fill-gray)};
   --color-fill-gray-secondary: #{dark-color(fill-gray-secondary)};
@@ -15,7 +16,6 @@
   --color-figure-blue: #{dark-color(figure-blue)};
   --color-figure-gray: #{dark-color(figure-gray)};
   --color-figure-gray-secondary: #{dark-color(figure-gray-secondary)};
-  --color-figure-gray-secondary-alt: #{dark-color(figure-gray-secondary-alt)};
   --color-figure-gray-tertiary: #{dark-color(figure-gray-tertiary)};
   --color-figure-green: #{dark-color(figure-green)};
   --color-figure-light-gray: #{dark-color(figure-light-gray)};

--- a/assets/stylesheets/core/colors/_light.scss
+++ b/assets/stylesheets/core/colors/_light.scss
@@ -6,7 +6,7 @@
   --color-fill: #{light-color(fill)};
   --color-fill-secondary: #{light-color(fill-secondary)};
   --color-fill-tertiary: #{light-color(fill-tertiary)};
-  --color-fill-quaternary: #{base-color(fill-quaternary)};
+  --color-fill-quaternary: #{light-color(fill-quaternary)};
   --color-fill-blue: #{light-color(fill-blue)};
   --color-fill-gray: #{light-color(fill-gray)};
   --color-fill-gray-secondary: #{light-color(fill-gray-secondary)};
@@ -16,7 +16,6 @@
   --color-figure-blue: #{light-color(figure-blue)};
   --color-figure-gray: #{light-color(figure-gray)};
   --color-figure-gray-secondary: #{light-color(figure-gray-secondary)};
-  --color-figure-gray-secondary-alt: #{light-color(figure-gray-secondary-alt)};
   --color-figure-gray-tertiary: #{light-color(figure-gray-tertiary)};
   --color-figure-green: #{light-color(figure-green)};
   --color-figure-light-gray: #{light-color(figure-light-gray)};
@@ -69,7 +68,7 @@
   );
   --color-code-background: var(--color-fill-secondary);
   --color-code-collapsible-background: var(--color-fill-tertiary);
-  --color-code-collapsible-text: var(--color-figure-gray-secondary-alt);
+  --color-code-collapsible-text: var(--color-figure-gray-tertiary);
   --color-code-plain: var(--color-figure-gray);
   --color-content-table-content-color: var(--color-fill-secondary);
   --color-dropdown-background: #{transparentize(light-color(fill), 0.2)};
@@ -96,7 +95,7 @@
   --color-hero-eyebrow: #{dark-color(figure-gray-secondary)};
   --color-link: var(--color-figure-blue);
   --color-loading-placeholder-background: var(--color-fill);
-  --color-nav-color: #{light-color(figure-gray-secondary-alt)};
+  --color-nav-color: #{light-color(figure-gray-tertiary)};
   --color-nav-current-link: #{change-color(
       light-color(figure-gray),
       $alpha: 0.6
@@ -123,7 +122,7 @@
       light-color(fill),
       $alpha: 0.4
     )};
-  --color-nav-dark-color: #{dark-color(figure-gray-secondary-alt)};
+  --color-nav-dark-color: #{dark-color(figure-gray-tertiary)};
   --color-nav-dark-current-link: #{change-color(
       dark-color(figure-gray),
       $alpha: 0.6


### PR DESCRIPTION
Removes figure-gray-secondary-alt in favor of figure-gray-tertiary which already had the exact same color values.

Fixes fill-quaternary to have different colors in dark and light mode.
