### PR TITLE
Fix upcoming feature flag search on SE dashboard

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -763,7 +763,7 @@ function _searchProposals(filterText) {
       ['trackingBugs', 'status'],
       ['trackingBugs', 'id'],
       ['trackingBugs', 'assignee'],
-      ['upcomingFeatureFlag']
+      ['upcomingFeatureFlag', 'flag']
   ]
 
   // Reflect over the proposals and find ones with matching properties


### PR DESCRIPTION
This PR updates the search path for upcoming feature flags in the SE dashboard script to match the upcoming metadata changes.

It restores the ability to search for upcoming feature flags on the SE dashboard.