### PR TITLE
Updated Community Showcase packages

### DIFF
--- a/_data/packages/packages.yml
+++ b/_data/packages/packages.yml
@@ -9,77 +9,81 @@ categories:
       organised via [this thread in the Swift Forums](https://forums.swift.org/t/68168)
       and curated by the [Swift Website Workgroup](https://www.swift.org/website-workgroup/).
     packages:
-      - name: GodotVision
-        description: Create shared-space experiences in Godot for visionOS, integrating
-          Godot's headless mode with RealityKit for 3D content mirroring.
-        owner: Kevin Watters
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (visionOS)
-        license: MIT
-        url: https://swiftpackageindex.com/kevinw/GodotVision
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/28){:target='_blank'}.
-      - name: whisperkit
-        description: Integrates OpenAI's Whisper speech recognition model with CoreML
-          for efficient, local inference on Apple devices.
-        owner: argmax, inc.
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS)
-        license: MIT
-        url: https://swiftpackageindex.com/argmaxinc/WhisperKit
-        note: Discussed on [Episode 42 of Swift Package Indexing](https://share.transistor.fm/s/c118cc9c){:target='_blank'}.
-      - name: GeoURI
-        description: Implements the geo URI scheme in Swift for identifying RFC 5870 compliant
-          physical locations via URI, including CoreLocation integration.
-        owner: Designed by Clowns
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-        license: The Unlicense
-        url: https://swiftpackageindex.com/designedbyclowns/GeoURI
-        note: Discussed on [Episode 43 of Swift Package Indexing](https://share.transistor.fm/s/2d4b1ba7){:target='_blank'}.
-      - name: swift-perception
-        description: Offers observation tools for earlier versions of Swift, mimicking
-          `@Observable` and providing compatibility with newer Swift observation features.
-        owner: Point-Free
-        swift_compatibility: 5.9+
+      - name: hummingbird
+        description: Hummingbird is a lightweight, flexible server framework written in
+          Swift. It consists of an HTTP server, a web application framework, and extension
+          modules.
+        owner: Hummingbird
+        swift_compatibility: 5.8+
         platform_compatibility:
           - Apple
           - Linux
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
           Linux
+        license: Apache 2.0
+        url: https://swiftpackageindex.com/hummingbird-project/hummingbird
+        note: Discussed on [Episode 45 of Swift Package Indexing](https://share.transistor.fm/s/53ee9157){:target='_blank'}.
+      - name: ContrastKit
+        description: Colour contrast handling and accessibility helpers by generating
+          colour shades and determining readable contrast colours according to accessibility
+          standards.
+        owner: Mark Battistella
+        swift_compatibility: 5.10+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
         license: MIT
-        url: https://swiftpackageindex.com/pointfreeco/swift-perception
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/24){:target='_blank'}.
-      - name: AsyncChannels
-        description: Enables performant, typed communication across Swift async tasks,
-          inspired by Go's channels, including buffered and un-buffered operations.
-        owner: Brian Floersch
+        url: https://swiftpackageindex.com/markbattistella/ContrastKit
+        note: Discussed on [Episode 45 of Swift Package Indexing](https://share.transistor.fm/s/53ee9157){:target='_blank'}.
+      - name: node-swift
+        description: Write Swift code that talks to Node.js libraries, and vice versa,
+          targeting cross-platform development with memory safety and idiomatic integration.
+        owner: Kabir Oberai
+        swift_compatibility: 5.10+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS)
+        license: MIT
+        url: https://swiftpackageindex.com/kabiroberai/node-swift
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/60){:target='_blank'}.
+      - name: AcmeSwift
+        description: Let's Encrypt certificate management handling account creation, order
+          submission, and certificate issuance with ACME v2. Requires external challenge
+          verification.
+        owner: Matthieu Barthelemy
         swift_compatibility: 5.8+
         platform_compatibility:
           - Apple
           - Linux
         platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
         license: MIT
-        url: https://swiftpackageindex.com/gh123man/Async-Channels
-        note: Discussed on [Episode 42 of Swift Package Indexing](https://share.transistor.fm/s/c118cc9c){:target='_blank'}.
-      - name: ExpectToEventuallyEqual
-        description: Provides an XCTest assertion for testing asynchronous code by repeatedly
-          evaluating conditions until they are met or time out.
-        owner: Jon Reid
-        swift_compatibility: 5.8+
+        url: https://swiftpackageindex.com/m-barthelemy/AcmeSwift
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/63){:target='_blank'}.
+      - name: BlurHashViews
+        description: Decodes BlurHash strings into SwiftUI views, offering customization
+          like contrast control, detail level, and color space adjustments for native
+          placeholders. Supports animations and custom transitions.
+        owner: Dale Price
+        swift_compatibility: 6.0+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+        license: MIT
+        url: https://swiftpackageindex.com/daprice/BlurHashViews
+        note: Linked to in [Issue 666 of iOS Dev Weekly](https://iosdevweekly.com/issues/666#aCUCaK0){:target='_blank'}.
+      - name: CodableDatastore
+        description: Database-like persistent storage for apps, supporting single-write-multiple-read
+          environments, with a focus on Codable structs for data modeling and indexing.
+        owner: Mochi Development, Inc.
+        swift_compatibility: 5.9+
         platform_compatibility:
           - Apple
           - Linux
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
           Linux
         license: MIT
-        url: https://swiftpackageindex.com/jonreid/ExpectToEventuallyEqual
-        note: Discussed on [Episode 41 of Swift Package Indexing](https://share.transistor.fm/s/861890bb){:target='_blank'}.
+        url: https://swiftpackageindex.com/mochidev/CodableDatastore
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/63){:target='_blank'}.
   - name: Packages with Macros
     slug: macros
     brief: New in Swift 5.9, Swift packages can include macro targets. Browse a selection
@@ -460,6 +464,17 @@ categories:
           Linux
         license: Apache 2.0
         url: https://swiftpackageindex.com/apple/swift-log
+      - name: Datadog
+        description: This library provides Swift and Objective-C SDKs to interact with
+          Datadog. It includes features for log collection, trace collection, and RUM
+          events collection.
+        owner: Datadog, Inc.
+        swift_compatibility: 5.9+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, visionOS, tvOS)
+        license: Apache 2.0
+        url: https://swiftpackageindex.com/DataDog/dd-sdk-ios
       - name: SwiftyBeaver
         description: SwiftyBeaver is a flexible, colorful, lightweight logging library
           for Swift. It supports console, file, and cloud destinations and is ideal for
@@ -472,17 +487,6 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS, watchOS, tvOS) and Linux
         license: MIT
         url: https://swiftpackageindex.com/SwiftyBeaver/SwiftyBeaver
-      - name: Datadog
-        description: This library provides Swift and Objective-C SDKs to interact with
-          Datadog. It includes features for log collection, trace collection, and RUM
-          events collection.
-        owner: Datadog, Inc.
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, visionOS, tvOS)
-        license: Apache 2.0
-        url: https://swiftpackageindex.com/DataDog/dd-sdk-ios
       - name: XCGLogger
         description: XCGLogger is a debug log module for Swift projects that allows you
           to log details to the console (and optionally a file) with additional information

--- a/_data/packages/showcase-history.yml
+++ b/_data/packages/showcase-history.yml
@@ -1,6 +1,158 @@
 years:
   - year: 2024
     months:
+      - month: June
+        slug: june
+        packages:
+          - name: rabbitmq-nio
+            description: Implements the AMQP 0.9.1 protocol in Swift, providing decoder,
+              encoder, and a non-blocking client for asynchronous messaging operations,
+              with ongoing development for stability and feature enhancements.
+            owner: Krzysztof Majk
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/funcmike/rabbitmq-nio
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/48){:target='_blank'}.
+          - name: Pack
+            description: Serialization and deserialization of binary data, not based on
+              key/value pairs, offering an alternative to `Codable` for efficient storage.
+            owner: Matt Cox
+            swift_compatibility: 5.8+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/mattcox/Pack
+            note: Discussed on [Episode 43 of Swift Package Indexing](https://share.transistor.fm/s/2d4b1ba7){:target='_blank'}.
+          - name: HandShadows
+            description: Make better demo videos for your apps by enabling shadows of a
+              hand hovering over the screen performing taps and gestures while using your
+              app.
+            owner: Adam Wulf
+            swift_compatibility: 5.8+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, visionOS)
+            license: MIT
+            url: https://swiftpackageindex.com/adamwulf/HandShadows
+            note: Linked to in [Issue 645 of iOS Dev Weekly](https://iosdevweekly.com/issues/645#AEv9Pwx){:target='_blank'}.
+          - name: WasmKit
+            description: WasmKit enables standalone and embeddable WebAssembly runtime execution,
+              supporting command line use and integration as a library, with partial WebAssembly
+              and WASI spec implementation.
+            owner: SwiftWasm
+            swift_compatibility: 5.8+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (macOS) and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/swiftwasm/WasmKit
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/53){:target='_blank'}.
+          - name: Fit
+            description: Automates SwiftUI view layouts into lines with customizable alignments,
+              spacings, and line-breaking without manual grouping or measuring.
+            owner: Oleh Korchytskyi
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/OlehKorchytskyi/Fit
+            note: Discussed on [Episode 43 of Swift Package Indexing](https://share.transistor.fm/s/2d4b1ba7){:target='_blank'}.
+          - name: swift-security
+            description: Enhances Apple's Security framework usage with compile-time checks
+              and consistent behavior across different platforms, focusing on Keychain,
+              cryptography, and shared web credentials.
+            owner: Dmitriy Zharov
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/dm-zharov/swift-security
+            note: Discussed on [Episode 43 of Swift Package Indexing](https://share.transistor.fm/s/2d4b1ba7){:target='_blank'}.
+      - month: May
+        slug: may
+        packages:
+          - name: GodotVision
+            description: Create shared-space experiences in Godot for visionOS, integrating
+              Godot's headless mode with RealityKit for 3D content mirroring.
+            owner: Kevin Watters
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (visionOS)
+            license: MIT
+            url: https://swiftpackageindex.com/kevinw/GodotVision
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/28){:target='_blank'}.
+          - name: whisperkit
+            description: Integrates OpenAI's Whisper speech recognition model with CoreML
+              for efficient, local inference on Apple devices.
+            owner: argmax, inc.
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS)
+            license: MIT
+            url: https://swiftpackageindex.com/argmaxinc/WhisperKit
+            note: Discussed on [Episode 42 of Swift Package Indexing](https://share.transistor.fm/s/c118cc9c){:target='_blank'}.
+          - name: GeoURI
+            description: Implements the geo URI scheme in Swift for identifying RFC 5870
+              compliant physical locations via URI, including CoreLocation integration.
+            owner: Designed by Clowns
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+            license: The Unlicense
+            url: https://swiftpackageindex.com/designedbyclowns/GeoURI
+            note: Discussed on [Episode 43 of Swift Package Indexing](https://share.transistor.fm/s/2d4b1ba7){:target='_blank'}.
+          - name: swift-perception
+            description: Offers observation tools for earlier versions of Swift, mimicking
+              `@Observable` and providing compatibility with newer Swift observation features.
+            owner: Point-Free
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/pointfreeco/swift-perception
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/24){:target='_blank'}.
+          - name: AsyncChannels
+            description: Enables performant, typed communication across Swift async tasks,
+              inspired by Go's channels, including buffered and un-buffered operations.
+            owner: Brian Floersch
+            swift_compatibility: 5.8+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/gh123man/Async-Channels
+            note: Discussed on [Episode 42 of Swift Package Indexing](https://share.transistor.fm/s/c118cc9c){:target='_blank'}.
+          - name: ExpectToEventuallyEqual
+            description: Provides an XCTest assertion for testing asynchronous code by repeatedly
+              evaluating conditions until they are met or time out.
+            owner: Jon Reid
+            swift_compatibility: 5.8+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/jonreid/ExpectToEventuallyEqual
+            note: Discussed on [Episode 41 of Swift Package Indexing](https://share.transistor.fm/s/861890bb){:target='_blank'}.
       - month: April
         slug: april
         packages:
@@ -17,9 +169,8 @@ years:
             url: https://swiftpackageindex.com/airbnb/lottie-ios
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/27){:target='_blank'}.
           - name: Citadel
-            description: Facilitates easy SSH client and server operations, TCP-IP forwarding,
-              command execution, and SFTP functionality with Swift NIOSSH enhancing its
-              capabilities.
+            description: Easy SSH client and server operations, TCP-IP forwarding, command
+              execution, and SFTP functionality with Swift NIOSSH enhancing its capabilities.
             owner: Orlandos Technologies - OpenSource
             swift_compatibility: 5.8+
             platform_compatibility:


### PR DESCRIPTION
This update contains new [Community Showcase packages](https://www.swift.org/packages/showcase.html).

I don’t know how I managed to forget this but the June packages never made it onto the site, so this PR includes both June *and* July packages.

Packages in the Community Showcase are nominated by the community in [this thread on the Swift forums](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168) and voted on by the [SWWG](https://www.swift.org/website-workgroup/).

![Screenshot 2024-07-04 at 13 05 27@2x](https://github.com/swiftlang/swift-org-website/assets/5180/783ac618-845a-48e9-9382-652bc676bdf9)