### PR TITLE
Clarify that package manifests must be located at the root of the repository in the Conceptual Overview section of the SwiftPM page

### DIFF
--- a/documentation/package-manager/_basic-usage.md
+++ b/documentation/package-manager/_basic-usage.md
@@ -58,7 +58,7 @@ example-package-playingcard
 └── Package.swift
 ~~~
 
-When creating a library package intended for use by other projects, the `Package.swift` manifest must reside at the top level/root of the package directory structure.
+When creating a library package intended for use as a dependency in other projects, the `Package.swift` manifest must reside at the top level/root of the package directory structure.
 
 Because the `PlayingCard` target does not produce an executable,
 it can be described as a _library_.

--- a/documentation/package-manager/_basic-usage.md
+++ b/documentation/package-manager/_basic-usage.md
@@ -58,6 +58,8 @@ example-package-playingcard
 └── Package.swift
 ~~~
 
+When creating a library package intended for use by other projects, the `Package.swift` manifest must reside at the top level/root of the package directory structure.
+
 Because the `PlayingCard` target does not produce an executable,
 it can be described as a _library_.
 A library is a target that builds a module which can be imported by other packages.

--- a/documentation/package-manager/_basic-usage.md
+++ b/documentation/package-manager/_basic-usage.md
@@ -58,13 +58,15 @@ example-package-playingcard
 └── Package.swift
 ~~~
 
-When creating a library package intended for use as a dependency in other projects, the `Package.swift` manifest must reside at the top level/root of the package directory structure.
-
 Because the `PlayingCard` target does not produce an executable,
 it can be described as a _library_.
 A library is a target that builds a module which can be imported by other packages.
 By default, a library module exposes all of the `public` types and methods
 declared in source code located in the `Sources/<target-name>` directory.
+
+When creating a library package intended for use as a dependency in other projects,
+the `Package.swift` manifest must reside at the top level/root of the
+package directory structure.
 
 Run `swift build` to start the Swift build process.
 If everything worked correctly,

--- a/documentation/package-manager/_conceptual-overview.md
+++ b/documentation/package-manager/_conceptual-overview.md
@@ -26,10 +26,10 @@ rather than reimplementing the same functionality yourself.
 
 ### Packages
 
-A _package_ consists of Swift source files and a manifest file.
-The manifest file, called `Package.swift`,
-defines the package's name and its contents
-using the `PackageDescription` module.
+A _package_ consists of Swift source files and a manifest file.
+The manifest must be located in the root of the package's repository and be
+named `Package.swift`, defining the package's name and other metadata
+using the `PackageDescription` module.
 
 {% comment %}
     TODO: "You can find API documentation for the `PackageDescription` module here: ..."

--- a/documentation/package-manager/_conceptual-overview.md
+++ b/documentation/package-manager/_conceptual-overview.md
@@ -26,10 +26,10 @@ rather than reimplementing the same functionality yourself.
 
 ### Packages
 
-A _package_ consists of Swift source files and a manifest file.
-The manifest must be located in the root of the package's repository and be
-named `Package.swift`, defining the package's name and other metadata
-using the `PackageDescription` module.
+A _package_ consists of Swift source files and a manifest file.
+The manifest file, called `Package.swift`,
+defines the package's name and its contents
+using the `PackageDescription` module.
 
 {% comment %}
     TODO: "You can find API documentation for the `PackageDescription` module here: ..."


### PR DESCRIPTION
### Motivation:

We recently had [an issue](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/discussions/3197) raised with SPI where someone thought the rule that `Package.swift` manifests must be located at the root of the package repository was something that SPI was enforcing rather than a SwftPM requirement.

I thought (and subsequently double-checked) that it was a SwiftPM requirement for library packages, but my first step in those checks was to search the web and this page was the first official source that came up. It struck me that this would be a good place to make this requirement clear.

### Modifications:

Clarified the Creating a Library Package section of the SwiftPM page to make this clear.

### Result:

![Screenshot 2024-07-15 at 13 09 04@2x](https://github.com/user-attachments/assets/057d8dc4-a1ce-4240-8b27-3ab89b73e888)