### PR TITLE
[Markdown] A few improvements to mentorship page 

### DIFF
--- a/mentorship/index.md
+++ b/mentorship/index.md
@@ -3,11 +3,11 @@ layout: page
 title: Swift Mentorship Program
 ---
 
-The Swift Mentorship Program is designed to encourage developers to actively participate in the Swift open source community through direct mentorship with experienced developers. The program is open to everyone! The program also looks to foster mentorship relationships within Swift’s [community groups](/diversity/#community-groups), for those who are interested. Members of Women in Swift, Black in Swift, and Pride in Swift are strongly encouraged to participate!
+The Swift Mentorship Program is designed to encourage developers to actively participate in the Swift open source community through direct mentorship with experienced developers. The program is open to everyone! The program also looks to foster mentorship relationships within Swift's [community groups](/diversity/#community-groups), for those who are interested. Members of Women in Swift, Black in Swift, and Pride in Swift are strongly encouraged to participate!
 
 Each mentee will have the opportunity to connect with and learn from an experienced developer within the Swift community, with the goal of them contributing code directly to an open-source project. The mentee can contribute to any open-source project written in Swift, or even in the Swift compiler itself, depending on the mentee's learning goals. Mentors and mentees will be matched based on the learning goals of the mentee and the experience of the mentor.
 
-If the mentee has not contributed to the project before, they will first work with their mentor to submit their first patch and overcome any workflow hurdles. The core of the mentorship program is making contributions that work toward the mentee’s learning goals. These contributions can range from implementing a small feature within the project, to several independent bug fixes within the same area of the project. At the end of the mentorship, mentees will have an opportunity for their contributions and learnings to be featured in a dedicated post on the Swift.org blog.
+If the mentee has not contributed to the project before, they will first work with their mentor to submit their first patch and overcome any workflow hurdles. The core of the mentorship program is making contributions that work toward the mentee's learning goals. These contributions can range from implementing a small feature within the project, to several independent bug fixes within the same area of the project. At the end of the mentorship, mentees will have an opportunity for their contributions and learnings to be featured in a dedicated post on the Swift.org blog.
 
 ## Current Program
 
@@ -31,7 +31,7 @@ The 2024 interest survey submissions will be open in accordance with the above t
 
 The mentee interest survey is not an application; but rather it will tell the Contributor Experience workgroup about your technical interests and learning goals, which will be used to help match you with a suitable mentor. Although the survey won't be evaluated like an application, the workgroup may not be able to match every interested mentee if there aren't enough mentors, or if none of the mentors are equipped to help with your specific learning goals.
 
-The Swift Mentorship Program is also a leadership opportunity for veteran community members, particularly if they are already an open-source project maintainer or frequent contributor. If you’re passionate about lowering the barrier to entry for new contributors in our community, please consider getting involved as a mentor!
+The Swift Mentorship Program is also a leadership opportunity for veteran community members, particularly if they are already an open-source project maintainer or frequent contributor. If you're passionate about lowering the barrier to entry for new contributors in our community, please consider getting involved as a mentor!
 
 ## Frequently Asked Questions
 
@@ -40,7 +40,7 @@ Participation in the Swift Mentorship program is governed by the [Swift Code of 
 <details class="download">
   <summary>How are mentor/mentee pairs selected?</summary>
 
-Mentors and mentees will each fill out an interest survey. The survey is not an application, but rather it tells the Contributor Experience workgroup about the participant’s interests, experience, learning goals, and more, which will be used to help the workgroup match mentor-mentee pairs. The interest surveys have a parallel set of questions to help evaluate whether the mentor has suitable experience to help the mentee with their learning goals. For example, the mentee questionnaire asks the mentee which specific skills/topics they are interested in working on, and the mentor questionnaire asks which specific skills/topics the mentor has experience with and can help a mentee learn about. A potential mentee will not be matched with a mentor if there are not enough mentors, or if there is not a suitable mentor to help them with their learning goals.
+Mentors and mentees will each fill out an interest survey. The survey is not an application, but rather it tells the Contributor Experience workgroup about the participant's interests, experience, learning goals, and more, which will be used to help the workgroup match mentor-mentee pairs. The interest surveys have a parallel set of questions to help evaluate whether the mentor has suitable experience to help the mentee with their learning goals. For example, the mentee questionnaire asks the mentee which specific skills/topics they are interested in working on, and the mentor questionnaire asks which specific skills/topics the mentor has experience with and can help a mentee learn about. A potential mentee will not be matched with a mentor if there are not enough mentors, or if there is not a suitable mentor to help them with their learning goals.
 </details>
 
 <details class="download">
@@ -51,7 +51,7 @@ Mentors must be members of the Swift community (e.g., iOS developers, Swift comp
 </details>
 
 <details class="download">
-  <summary>I’m not a student. Can I still be a mentee?</summary>
+  <summary>I'm not a student. Can I still be a mentee?</summary>
 
 Yes! This mentorship program is not limited to students.
 </details>
@@ -59,7 +59,7 @@ Yes! This mentorship program is not limited to students.
 <details class="download">
   <summary>What should I expect from my mentor?</summary>
 
-You can expect your mentor to help guide you as you make contributions to an open source project, provide constructive feedback on your work, share their own experiences, and help you navigate the Swift community! You should not expect your mentor to make sure your contributions are accepted or assign work to you. You also should not expect your mentor to directly teach you. Think of your mentor as a teaching assistant rather than a teacher — they may suggest resources to aid your learning, answer questions, and discuss what you’ve learned, but they are not expected to give you a lecture on a technical concept.
+You can expect your mentor to help guide you as you make contributions to an open source project, provide constructive feedback on your work, share their own experiences, and help you navigate the Swift community! You should not expect your mentor to make sure your contributions are accepted or assign work to you. You also should not expect your mentor to directly teach you. Think of your mentor as a teaching assistant rather than a teacher — they may suggest resources to aid your learning, answer questions, and discuss what you've learned, but they are not expected to give you a lecture on a technical concept.
 </details>
 
 <details class="download">
@@ -71,7 +71,7 @@ Mentors are expected to allocate at least a half hour per week to meet with thei
 <details class="download">
   <summary>How will mentors and mentees communicate?</summary>
 
-Most communication is expected to happen asynchronously on the Swift Forums. The mentorship pair may also decide to meet “face to face” via video chat or similar.
+Most communication is expected to happen asynchronously on the Swift Forums. The mentorship pair may also decide to meet "face to face" via video chat or similar.
 </details>
 
 <details class="download">
@@ -83,17 +83,17 @@ Most communication is expected to happen asynchronously on the Swift Forums. The
 <details class="download">
   <summary>How are open source tasks for mentees identified?</summary>
 
-If the mentee does not have any ideas in mind, project maintainers and mentors may identify starter tasks that are suitable for newcomers to the project. For example, a <a href="/contributing/#good-first-issues">good first issue</a>. Beyond the initial contribution, mentors or mentees may suggest small “projects” that are implementable given the expected time commitment. Otherwise, every open source project has an endless supply of issues to be fixed! Participants may rely on the issue tracking system for the open source project to identify these tasks.
+If the mentee does not have any ideas in mind, project maintainers and mentors may identify starter tasks that are suitable for newcomers to the project. For example, a <a href="/contributing/#good-first-issues">good first issue</a>. Beyond the initial contribution, mentors or mentees may suggest small "projects" that are implementable given the expected time commitment. Otherwise, every open source project has an endless supply of issues to be fixed! Participants may rely on the issue tracking system for the open source project to identify these tasks.
 </details>
 
 <details class="download">
   <summary>Is there an evaluation at the end of the program?</summary>
 
-There is no formal evaluation at the end of the mentorship program. However, there will be an opt-in exit survey for all participants. There will also be a post on the Swift.org blog to highlight mentees’ contributions and their learnings.
+There is no formal evaluation at the end of the mentorship program. However, there will be an opt-in exit survey for all participants. There will also be a post on the Swift.org blog to highlight mentees' contributions and their learnings.
 </details>
 
 <details class="download">
-  <summary>I’m interested in being a mentor! What should I do?</summary>
+  <summary>I'm interested in being a mentor! What should I do?</summary>
 
 Please fill out the <a href="https://essentials.applesurveys.com/jfe/form/SV_3CSIxEKQmL1MVhQ">Mentor Interest Survey</a> if you are interested in participating as a mentor.
 </details>

--- a/mentorship/index.md
+++ b/mentorship/index.md
@@ -27,7 +27,10 @@ If the mentee has not contributed to the project before, they will first work wi
 
 ### Participation
 
-The 2024 interest survey submissions will be open in accordance with the above timeline. If you are interested in participating as a mentor, please fill out the interest survey [here](https://essentials.applesurveys.com/jfe/form/SV_3CSIxEKQmL1MVhQ).
+The 2024 interest survey submissions will be open in accordance with the above timeline. If you are interested in participating as:
+
+* A mentor, please fill out the interest survey [here](https://essentials.applesurveys.com/jfe/form/SV_3CSIxEKQmL1MVhQ).
+* A mentee, please fill out the interest survey [here](https://essentials.applesurveys.com/jfe/form/SV_1ZzrYvo7xQP4i3k).
 
 The mentee interest survey is not an application; but rather it will tell the Contributor Experience workgroup about your technical interests and learning goals, which will be used to help match you with a suitable mentor. Although the survey won't be evaluated like an application, the workgroup may not be able to match every interested mentee if there aren't enough mentors, or if none of the mentors are equipped to help with your specific learning goals.
 

--- a/mentorship/index.md
+++ b/mentorship/index.md
@@ -25,9 +25,9 @@ If the mentee has not contributed to the project before, they will first work wi
 | **October 14th**   |  10-week cohort ends             |
 | **October 21st**   |  Feedback deadline               |
 
-### Interest Surveys
+### Participation
 
-The 2024 mentor interest survey submissions are open from June 17th - July 1st. If you are interested in participating as a mentor, please fill out the interest survey [here](https://essentials.applesurveys.com/jfe/form/SV_3CSIxEKQmL1MVhQ).
+The 2024 interest survey submissions will be open in accordance with the above timeline. If you are interested in participating as a mentor, please fill out the interest survey [here](https://essentials.applesurveys.com/jfe/form/SV_3CSIxEKQmL1MVhQ).
 
 The mentee interest survey is not an application; but rather it will tell the Contributor Experience workgroup about your technical interests and learning goals, which will be used to help match you with a suitable mentor. Although the survey won't be evaluated like an application, the workgroup may not be able to match every interested mentee if there aren't enough mentors, or if none of the mentors are equipped to help with your specific learning goals.
 
@@ -65,7 +65,7 @@ You can expect your mentor to help guide you as you make contributions to an ope
 <details class="download">
   <summary>What is the expected time commitment?</summary>
 
-Mentors are expected to meet with their mentees at least 2 hours per month. The mentorship pair can decide how to distribute that time throughout the month. Mentees are expected to spend at least an additional 2 hours per month working on their contributions.
+Mentors are expected to allocate at least a half hour per week to meet with their mentees. The mentorship pair can decide how to distribute that time throughout the program. Mentees are expected to spend at least an additional half hour per week working on their contributions.
 </details>
 
 <details class="download">
@@ -89,7 +89,7 @@ If the mentee does not have any ideas in mind, project maintainers and mentors m
 <details class="download">
   <summary>Is there an evaluation at the end of the program?</summary>
 
-There is no formal evaluation at the end of the mentorship program. However, there will be an exit survey for all participants. There will also be a post on the Swift.org blog to highlight mentees’ contributions and their learnings.
+There is no formal evaluation at the end of the mentorship program. However, there will be an opt-in exit survey for all participants. There will also be a post on the Swift.org blog to highlight mentees’ contributions and their learnings.
 </details>
 
 <details class="download">


### PR DESCRIPTION
### Modifications:

* Change heading from "Interest Surveys" to "Participation". The latter
  is a simpler and more catchy word.
* Don't repeat info that is already in the timeline.
* The program duration is measured in weeks. Express time commitment in
  hours/week too.
* Clarify that the exit survey is not compulsory.
* Add link to mentee interest survey
