### PR TITLE
Fix SSWG links

### DIFF
--- a/documentation/server/index.md
+++ b/documentation/server/index.md
@@ -72,5 +72,5 @@ The workgroup:
 * Defines and runs an incubation process for these efforts to reduce duplication of effort, increase compatibility, and promote best practices.
 * Channels feedback for Swift language features needed by the server development community to the Swift Core Team.
 
-Read more about the [workgroup](/sswg "Swift Server Workgroup") and server incubator it runs [here](/sswg/incubation-process "SSWG Incubation Process").
+Read more about the [workgroup](/sswg "Swift Server Workgroup") and server incubator it runs [here](/sswg/incubation-process.html "SSWG Incubation Process").
 

--- a/sswg/incubated-packages.md
+++ b/sswg/incubated-packages.md
@@ -3,7 +3,7 @@ layout: page
 title: SSWG Incubated packages
 ---
 
-The Swift Server Workgroup ([SSWG](/sswg/)) has a [process](/sswg/incubation-process/) which allows a project to go through incubation stages until it graduates and becomes a recommended project.
+The Swift Server Workgroup ([SSWG](/sswg/)) has a [process](/sswg/incubation-process.html) which allows a project to go through incubation stages until it graduates and becomes a recommended project.
 
 <table>
   <thead>

--- a/sswg/incubation-process.md
+++ b/sswg/incubation-process.md
@@ -203,7 +203,7 @@ Updates resulting in a version bump require a super-majority vote from the SSWG.
 
 ## Resources and References
 
-- [Incubated packages](/sswg/incubated-packages)
+- [Incubated packages](/sswg/incubated-packages.html)
 * [Swift Evolution](https://www.swift.org/swift-evolution/)
 * [CNCF Project Lifecycle & Process](https://github.com/cncf/toc/tree/main/process)
 * [The Apache Incubator](https://incubator.apache.org)

--- a/sswg/index.md
+++ b/sswg/index.md
@@ -6,7 +6,7 @@ title: Swift Server Workgroup (SSWG)
 The Swift Server workgroup is a steering team that promotes the use of Swift for developing and deploying server applications. The Swift Server workgroup will:
 
 * Define and prioritize efforts that address the needs of the Swift server community.
-* Define and run an [incubation process](/sswg/incubation-process/) for these efforts to reduce duplication of effort, increase compatibility and promote best practices.
+* Define and run an [incubation process](/sswg/incubation-process.html) for these efforts to reduce duplication of effort, increase compatibility and promote best practices.
 * Channel feedback for Swift language features needed by the server development community to the Swift Core Team.
 
 Analogous to the [Core Team](/community#core-team) for Swift, the workgroup is responsible for providing overall technical direction and establishing the standards by which libraries and tools are proposed, developed and eventually recommended. Membership of the workgroup is contribution-based and is expected to evolve over time.


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

Fixes #759 

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

For some reason that I'm not sure of, some SSWG links, but not all, require the `.html` suffix. Is this some server setting? cc: @shahmishal

- Fixed 1 /sswg/incubated-packages.html link
- Fixed 3 /sswg/incubation-process.html links

### Result:

<!-- _[After your change, what will change.]_ -->

Links work again.
