### PR TITLE
Move steering groups to own section in community drop-down

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -63,6 +63,37 @@
           name: adding-external-library-dependencies
         - title: LLVM and Swift
           name: llvm-and-swift
+    - section: Steering Groups
+    - title: Language
+      url: /language-steering-group/
+      sections:
+        - title: Charter
+          name: charter
+        - title: Membership
+          name: membership
+        - title: Decision making
+          name: decision-making
+        - title: Communication
+          name: communication
+        - title: Evolution process
+          name: evolution-process
+        - title: Community participation
+          name: community-participation
+    - title: Platform
+      url: /platform-steering-group/
+      sections:
+        - title: Charter
+          name: charter
+        - title: Membership
+          name: membership
+        - title: Evolution
+          name: evolution
+        - title: Communication
+          name: communication
+        - title: Platform Evolution process
+          name: platform-evolution-process
+        - title: Community participation
+          name: community-participation
     - section: Workgroups
     - title: Contributor Experience
       url: /contributor-experience-workgroup/
@@ -84,36 +115,6 @@
           name: governance
         - title: Website workgroup
           name: website-workgroup
-    - title: Language Steering Group
-      url: /language-steering-group/
-      sections:
-        - title: Charter
-          name: charter
-        - title: Membership
-          name: membership
-        - title: Decision making
-          name: decision-making
-        - title: Communication
-          name: communication
-        - title: Evolution process
-          name: evolution-process
-        - title: Community participation
-          name: community-participation
-    - title: Platform Steering Group
-      url: /platform-steering-group/
-      sections:
-        - title: Charter
-          name: charter
-        - title: Membership
-          name: membership
-        - title: Evolution
-          name: evolution
-        - title: Communication
-          name: communication
-        - title: Platform Evolution process
-          name: platform-evolution-process
-        - title: Community participation
-          name: community-participation
     - title: C++ Interoperability
       url: /cxx-interop-workgroup/
       sections:


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

As steering groups are not workgroups ([blog post that explains the difference](https://www.swift.org/blog/evolving-swift-project-workgroups/)), I don't think they should not be listed under "workgroups", but rather in their own "steering groups" section.

I think this makes the community drop-down easier to understand and quicker to scan as well.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Moved steering groups into their own section and removed the "steering group" suffix

### Result:

<!-- _[After your change, what will change.]_ -->

|Before|After|
|---|---|
|![CleanShot 2024-07-15 at 18 34 56](https://github.com/user-attachments/assets/1e411de2-9fd1-4aa7-be49-188e060478e7)|![CleanShot 2024-07-15 at 18 34 13](https://github.com/user-attachments/assets/602e9b4a-414e-4a6c-8cd9-5f8f27547b4b)|

