### PR TITLE
Re-add Ubuntu 22.04 download section

### DIFF
--- a/_includes/linux/table.html
+++ b/_includes/linux/table.html
@@ -27,6 +27,10 @@
   {% include linux/ubuntu2310.html %}
 </details>
 <details class="download" style="margin-bottom: 0;">
+  <summary>Ubuntu 22.04</summary>
+  {% include linux/ubuntu2204.html %}
+</details>
+<details class="download" style="margin-bottom: 0;">
   <summary>Ubuntu 20.04</summary>
   {% include linux/ubuntu2004.html %}
 </details>

--- a/_includes/linux/ubuntu2204.html
+++ b/_includes/linux/ubuntu2204.html
@@ -6,13 +6,14 @@ $ apt-get install \
           libc6-dev \
           libcurl4-openssl-dev \
           libedit2 \
-          libgcc-9-dev \
-          libpython3.8 \
+          libgcc-11-dev \
+          libpython3-dev \
           libsqlite3-0 \
-          libstdc++-9-dev \
+          libstdc++-11-dev \
           libxml2-dev \
           libz3-dev \
           pkg-config \
+          python3-lldb-13 \
           tzdata \
           unzip \
           zlib1g-dev


### PR DESCRIPTION
### Motivation:

The website no longer has a section on the dependencies that should be downloaded on Ubuntu 22.04.
I assume this was mistakenly removed when adding Ubuntu 23.10 and 24.04.

<kbd> <img width="512" alt="Screenshot 2024-07-28 at 8 03 19 PM" src="https://github.com/user-attachments/assets/f76854c5-ca87-485f-be02-6596ba75133b"> </kbd>

https://www.swift.org/install/linux/tarball/

### Modifications:

Re-add that section.
The Ubuntu 22.04 dependencies have been updated as well, according to the [Dockerfiles](https://github.com/swiftlang/swift-docker/blob/main/5.10/ubuntu/22.04/Dockerfile).

### Result:

Users know what dependencies to install on Ubuntu 22.04.
