### PR TITLE
Add support for checksum to install page for static Linux SDK

### DIFF
--- a/_data/builds/development/static_sdk.yml
+++ b/_data/builds/development/static_sdk.yml
@@ -2,6 +2,7 @@
   dir: swift-DEVELOPMENT-SNAPSHOT-2024-07-02-a
   download: swift-DEVELOPMENT-SNAPSHOT-2024-07-02-a_static-linux-0.0.1.artifactbundle.tar.gz
   download_signature: swift-DEVELOPMENT-SNAPSHOT-2024-07-02-a_static-linux-0.0.1.artifactbundle.tar.gz.sig
+  checksum: e334e0068613b14538238a8be81952169c6fc780094f582505383cd9f5fe1c4c
 - date: 2024-06-13 10:10:00-06:00
   dir: swift-DEVELOPMENT-SNAPSHOT-2024-06-13-a
   download: swift-DEVELOPMENT-SNAPSHOT-2024-06-13-a_static-linux-0.0.1.artifactbundle.tar.gz

--- a/_data/builds/swift-6_0-branch/static_sdk.yml
+++ b/_data/builds/swift-6_0-branch/static_sdk.yml
@@ -2,6 +2,7 @@
   dir: swift-6.0-DEVELOPMENT-SNAPSHOT-2024-07-02-a
   download: swift-6.0-DEVELOPMENT-SNAPSHOT-2024-07-02-a_static-linux-0.0.1.artifactbundle.tar.gz
   download_signature: swift-6.0-DEVELOPMENT-SNAPSHOT-2024-07-02-a_static-linux-0.0.1.artifactbundle.tar.gz.sig
+  checksum: 42a361e1a240e97e4bb3a388f2f947409011dcd3d3f20b396c28999e9736df36
 - date: 2024-06-22 10:10:00-06:00
   dir: swift-6.0-DEVELOPMENT-SNAPSHOT-2024-06-22-a
   download: swift-6.0-DEVELOPMENT-SNAPSHOT-2024-06-22-a_static-linux-0.0.1.artifactbundle.tar.gz

--- a/_includes/install/_static_sdk_dev.md
+++ b/_includes/install/_static_sdk_dev.md
@@ -10,7 +10,10 @@
     <p class="description">
       Static Linux SDK - Cross compile to Linux
       <ul>
-        <li><a href="https://download.swift.org/development/static-sdk/{{ static_sdk_dev_builds.first.dir }}/{{ static_sdk_dev_builds.first.download_signature }}">Signature (PGP)</a></li>
+        <li><a href="https://download.swift.org/development/static-sdk/{{ static_sdk_dev_builds.first.dir }}/{{ static_sdk_dev_builds.first.download_signature }}">Signature (PGP)</a>
+        </li>
+        <li>
+          Checksum: <code>{{ static_sdk_dev_builds.first.checksum }}</code></li>
       </ul>
     </p>
     <a href="https://download.swift.org/development/static-sdk/{{ static_sdk_dev_builds.first.dir }}/{{ static_sdk_dev_builds.first.download }}" class="cta-secondary">Download Linux Static SDK</a>
@@ -24,6 +27,7 @@
       Static Linux SDK - Cross compile to Linux
       <ul>
         <li><a href="https://download.swift.org/swift-6.0-branch/static-sdk/{{ static_sdk_6_0_builds.first.dir }}/{{ static_sdk_6_0_builds.first.download_signature }}">Signature (PGP)</a></li>
+        <li>Checksum: <code>{{ static_sdk_6_0_builds.first.checksum }}</code></li>
       </ul>
     </p>
     <a href="https://download.swift.org/swift-6.0-branch/static-sdk/{{ static_sdk_6_0_builds.first.dir }}/{{ static_sdk_6_0_builds.first.download }}" class="cta-secondary">Download Linux Static SDK</a>


### PR DESCRIPTION

<img width="660" alt="Screenshot 2024-07-31 at 11 51 36 PM" src="https://github.com/user-attachments/assets/1fafc6a8-1b48-4c9c-a238-92b74e1b34fe">


To support the new feature in Swift Package Manager (static Linux SDK for Swift). 