### PR TITLE
Updated Community Showcase packages for August

### DIFF
--- a/_data/packages/packages.yml
+++ b/_data/packages/packages.yml
@@ -9,81 +9,78 @@ categories:
       organised via [this thread in the Swift Forums](https://forums.swift.org/t/68168)
       and curated by the [Swift Website Workgroup](https://www.swift.org/website-workgroup/).
     packages:
-      - name: hummingbird
-        description: Hummingbird is a lightweight, flexible server framework written in
-          Swift. It consists of an HTTP server, a web application framework, and extension
-          modules.
-        owner: Hummingbird
-        swift_compatibility: 5.8+
+      - name: DiscordBM
+        description: A multiplatform Discord library, primarily for making bots. It has
+          full support for Swift concurrency and type-safe APIs with abstractions for
+          easier testability.
+        owner: DiscordBM
+        swift_compatibility: 5.9+
+        platform_compatibility:
+          - Apple
+          - Linux
+        platform_compatibility_tooltip: Apple (iOS, macOS, watchOS, tvOS) and Linux
+        license: Apache 2.0
+        url: https://swiftpackageindex.com/DiscordBM/DiscordBM
+        note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/74){:target='_blank'}.
+      - name: swift-testing-revolutionary
+        description: A tool to convert XCTest cases to swift-testing format. It includes
+          an Xcode plugin, Swift package plugin, and a command line tool.
+        owner: Kohki Miki
+        swift_compatibility: 5.10+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (macOS)
+        license: MIT
+        url: https://swiftpackageindex.com/giginet/swift-testing-revolutionary
+        note: Discussed on [Episode 46 of Swift Package Indexing](https://share.transistor.fm/s/08c0a3f9){:target='_blank'}.
+      - name: swiftly
+        description: Manages Swift toolchain installations, allowing users to easily install,
+          switch between, and update various Swift versions and development snapshots.
+        owner: The Swift Programming Language
+        swift_compatibility: 5.10+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (macOS)
+        license: Apache 2.0
+        url: https://swiftpackageindex.com/swiftlang/swiftly
+        note: Discussed on [Episode 45 of Swift Package Indexing](https://share.transistor.fm/s/53ee9157){:target='_blank'}.
+      - name: SwiftFormats
+        description: Expands `FormatStyle` implementations for various types, enabling
+          advanced formatting and parsing for strings, including extensions for string
+          interpolation.
+        owner: Jonathan Wight
+        swift_compatibility: 5.10+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+        license: BSD 3-Clause
+        url: https://swiftpackageindex.com/schwa/SwiftFormats
+        note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/67){:target='_blank'}.
+      - name: WhatsNewKit
+        description: WhatsNewKit enables showcasing new app features with full customization,
+          supporting automatic and manual presentation modes across various platforms
+          and frameworks.
+        owner: Sven Tiigi
+        swift_compatibility: 5.9+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS)
+        license: MIT
+        url: https://swiftpackageindex.com/SvenTiigi/WhatsNewKit
+        note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/59){:target='_blank'}.
+      - name: swift-dom
+        description: Generate HTML and related formats using a memory-efficient, cross-platform,
+          efficient, expressive DSL.
+        owner: taylorswift
+        swift_compatibility: 5.10+
         platform_compatibility:
           - Apple
           - Linux
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
           Linux
         license: Apache 2.0
-        url: https://swiftpackageindex.com/hummingbird-project/hummingbird
-        note: Discussed on [Episode 45 of Swift Package Indexing](https://share.transistor.fm/s/53ee9157){:target='_blank'}.
-      - name: ContrastKit
-        description: Colour contrast handling and accessibility helpers by generating
-          colour shades and determining readable contrast colours according to accessibility
-          standards.
-        owner: Mark Battistella
-        swift_compatibility: 5.10+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-        license: MIT
-        url: https://swiftpackageindex.com/markbattistella/ContrastKit
-        note: Discussed on [Episode 45 of Swift Package Indexing](https://share.transistor.fm/s/53ee9157){:target='_blank'}.
-      - name: node-swift
-        description: Write Swift code that talks to Node.js libraries, and vice versa,
-          targeting cross-platform development with memory safety and idiomatic integration.
-        owner: Kabir Oberai
-        swift_compatibility: 5.10+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS)
-        license: MIT
-        url: https://swiftpackageindex.com/kabiroberai/node-swift
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/60){:target='_blank'}.
-      - name: AcmeSwift
-        description: Let's Encrypt certificate management handling account creation, order
-          submission, and certificate issuance with ACME v2. Requires external challenge
-          verification.
-        owner: Matthieu Barthelemy
-        swift_compatibility: 5.8+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
-        license: MIT
-        url: https://swiftpackageindex.com/m-barthelemy/AcmeSwift
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/63){:target='_blank'}.
-      - name: BlurHashViews
-        description: Decodes BlurHash strings into SwiftUI views, offering customization
-          like contrast control, detail level, and color space adjustments for native
-          placeholders. Supports animations and custom transitions.
-        owner: Dale Price
-        swift_compatibility: 6.0+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-        license: MIT
-        url: https://swiftpackageindex.com/daprice/BlurHashViews
-        note: Linked to in [Issue 666 of iOS Dev Weekly](https://iosdevweekly.com/issues/666#aCUCaK0){:target='_blank'}.
-      - name: CodableDatastore
-        description: Database-like persistent storage for apps, supporting single-write-multiple-read
-          environments, with a focus on Codable structs for data modeling and indexing.
-        owner: Mochi Development, Inc.
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: MIT
-        url: https://swiftpackageindex.com/mochidev/CodableDatastore
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/63){:target='_blank'}.
+        url: https://swiftpackageindex.com/tayloraswift/swift-dom
+        note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/66){:target='_blank'}.
   - name: Packages with Macros
     slug: macros
     brief: New in Swift 5.9, Swift packages can include macro targets. Browse a selection

--- a/_data/packages/showcase-history.yml
+++ b/_data/packages/showcase-history.yml
@@ -1,6 +1,80 @@
 years:
   - year: 2024
     months:
+      - month: July
+        slug: july
+        packages:
+          - name: hummingbird
+            description: Hummingbird is a lightweight, flexible server framework written
+              in Swift. It consists of an HTTP server, a web application framework, and
+              extension modules.
+            owner: Hummingbird
+            swift_compatibility: 5.8+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/hummingbird-project/hummingbird
+            note: Discussed on [Episode 45 of Swift Package Indexing](https://share.transistor.fm/s/53ee9157){:target='_blank'}.
+          - name: ContrastKit
+            description: Colour contrast handling and accessibility helpers by generating
+              colour shades and determining readable contrast colours according to accessibility
+              standards.
+            owner: Mark Battistella
+            swift_compatibility: 5.10+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/markbattistella/ContrastKit
+            note: Discussed on [Episode 45 of Swift Package Indexing](https://share.transistor.fm/s/53ee9157){:target='_blank'}.
+          - name: node-swift
+            description: Write Swift code that talks to Node.js libraries, and vice versa,
+              targeting cross-platform development with memory safety and idiomatic integration.
+            owner: Kabir Oberai
+            swift_compatibility: 5.10+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/kabiroberai/node-swift
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/60){:target='_blank'}.
+          - name: AcmeSwift
+            description: Let's Encrypt certificate management handling account creation,
+              order submission, and certificate issuance with ACME v2. Requires external
+              challenge verification.
+            owner: Matthieu Barthelemy
+            swift_compatibility: 5.8+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/m-barthelemy/AcmeSwift
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/63){:target='_blank'}.
+          - name: BlurHashViews
+            description: Decodes BlurHash strings into SwiftUI views, offering customization
+              like contrast control, detail level, and color space adjustments for native
+              placeholders. Supports animations and custom transitions.
+            owner: Dale Price
+            license: MIT
+            url: https://swiftpackageindex.com/daprice/BlurHashViews
+            note: Linked to in [Issue 666 of iOS Dev Weekly](https://iosdevweekly.com/issues/666#aCUCaK0){:target='_blank'}.
+          - name: CodableDatastore
+            description: Database-like persistent storage for apps, supporting single-write-multiple-read
+              environments, with a focus on Codable structs for data modeling and indexing.
+            owner: Mochi Development, Inc.
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/mochidev/CodableDatastore
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/63){:target='_blank'}.
       - month: June
         slug: june
         packages:


### PR DESCRIPTION
Merge after #777

This update contains the [Community Showcase packages](https://www.swift.org/packages/showcase.html) for August.

Packages in the Community Showcase are nominated by the community in [this thread on the Swift forums](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168) and voted on by the [SWWG](https://www.swift.org/website-workgroup/).

![Screenshot 2024-08-09 at 22 05 45@2x](https://github.com/user-attachments/assets/0deee0d9-784d-4f41-9d53-3f444e1581cc)
