### PR TITLE
Fix Sass deprecations

### DIFF
--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -505,14 +505,6 @@ footer[role="contentinfo"] {
     max-width: 700px;
 
     i {
-      &.twitter {
-        background-image: url("/assets/images/icon-twitter.svg");
-      }
-
-      &.feed {
-        background-image: url("/assets/images/icon-feed.svg");
-      }
-
       width: 16px;
       height: 16px;
       background-repeat: no-repeat;
@@ -520,6 +512,14 @@ footer[role="contentinfo"] {
       display: block;
       margin-left: 1em;
       float: right;
+
+      &.twitter {
+        background-image: url("/assets/images/icon-twitter.svg");
+      }
+
+      &.feed {
+        background-image: url("/assets/images/icon-feed.svg");
+      }
     }
   }
 }

--- a/assets/stylesheets/pages/_swift-evolution.scss
+++ b/assets/stylesheets/pages/_swift-evolution.scss
@@ -151,11 +151,12 @@
   }
 
   #status-filter-subhead {
+    line-height: 1rem;
+    margin-bottom: 1.3rem;
+
     &.hidden {
       display: none;
     }
-    line-height: 1rem;
-    margin-bottom: 1.3rem;
   }
 
   #status-filter-description {


### PR DESCRIPTION
### Motivation:

Sass's behavior for declarations that appear after nested rules will be changing to match the behavior specified by CSS in an upcoming version. To keep the existing behavior, move the declaration above the nested rule. To opt into the new behavior, wrap the declaration in `& {}`.

### Modifications:

Fixed the deprecations above

### Result:

Deprecations are not there anymore
