### PR TITLE
Improve multi-arch links detection by a generic solution and add Windows (arm64) to 6.0 release

### DIFF
--- a/_data/builds/swift_releases.yml
+++ b/_data/builds/swift_releases.yml
@@ -1807,6 +1807,7 @@
       docker: Coming Soon #6.0-windowsservercore-ltsc2022
       archs:
         - x86_64
+        - arm64
     - name: Static SDK
       platform: static-sdk
       checksum: 7984c2cf175bde52ba6ea1fcbe27fc4a148a6237c41c719209c9288ed3ceb652

--- a/_includes/install/_build_release.md
+++ b/_includes/install/_build_release.md
@@ -4,6 +4,10 @@
 {% assign tag_downcase = site.data.builds.swift_releases.last.tag | downcase %}
 {% assign platform_name_url = include.platform | remove: '.' | remove: ' ' | downcase %}
 {% assign platform_name = include.platform | remove : ' ' | downcase %}
+{% assign platform = site.data.builds.swift_releases.last.platforms | where: 'dir', include.platform_name_url | first %}
+{% unless platform %}
+  {% assign platform = site.data.builds.swift_releases.last.platforms | where: 'name', include.platform | first %}
+{% endunless %}
 
 <ul class="install-instruction">
   <li class="resource">
@@ -19,17 +23,21 @@
     <p class="description">
       Tarball packages (.tar.gz)
       <ul>
-        <li>Signature (PGP): <a href="https://download.swift.org/{{ tag_downcase }}/{{ platform_name_url }}/{{ tag }}/{{ tag }}-{{ platform_name }}.tar.gz.sig" >x86_64</a>{% if include.aarch64 %} | <a href="https://download.swift.org/{{ tag_downcase }}/{{ platform_name_url }}-aarch64/{{ tag }}/{{ tag }}-{{ platform_name }}-aarch64.tar.gz.sig">aarch64</a>{% endif %}</li>
+        <li>Signature (PGP):{{ ' ' }}
+          {%- for arch in platform.archs -%}
+          {%- unless forloop.first %} | {% endunless -%}
+          <a href="https://download.swift.org/{{ tag_downcase }}/{{ platform_name_url }}{% if arch != "x86_64" %}-{{ arch }}{% endif %}/{{ tag }}/{{ tag }}-{{ platform_name }}{% if arch != "x86_64" %}-{{ arch }}{% endif %}.tar.gz.sig" >
+            {{- arch -}}
+          </a>
+          {%- endfor -%}
+        </li>
       </ul>
     </p>
-    {% if include.aarch64 %}
     <ul class="install-instruction">
-      <a href="https://download.swift.org/{{ tag_downcase }}/{{ platform_name_url }}/{{ tag }}/{{ tag }}-{{ platform_name }}.tar.gz" class="cta-secondary">Download (x86_64)</a>
-      <a href="https://download.swift.org/{{ tag_downcase }}/{{ platform_name_url }}-aarch64/{{ tag }}/{{ tag }}-{{ platform_name }}-aarch64.tar.gz" class="cta-secondary">Download (aarch64)</a>
+      {% for arch in platform.archs %}
+      <a href="https://download.swift.org/{{ tag_downcase }}/{{ platform_name_url }}{% if arch != "x86_64" %}-{{ arch }}{% endif %}/{{ tag }}/{{ tag }}-{{ platform_name }}{% if arch != "x86_64" %}-{{ arch }}{% endif %}.tar.gz" class="cta-secondary">Download ({{ arch }})</a>
+      {% endfor %}
     </ul>
-    {% else %}
-    <a href="https://download.swift.org/{{ tag_downcase }}/{{ platform_name_url }}/{{ tag }}/{{ tag }}-{{ platform_name }}.tar.gz" class="cta-secondary">Download (x86_64)</a>
-    {% endif %}
     <a href="/install/linux/tarball" class="cta-secondary">Instructions</a>
   </li>
 </ul>

--- a/install/linux/amazonlinux/2/index.md
+++ b/install/linux/amazonlinux/2/index.md
@@ -9,7 +9,7 @@ title: Install Swift
 
 {% include install/_os_versions_tabs.md os_versions=site.data.install.amazonlinux  name="Amazon Linux" pressed="Amazon Linux 2" %}
 
-{% include install/_build_release.md platform="Amazon Linux 2" docker_tag="amazonlinux2" aarch64="true" rpm="true"%}
+{% include install/_build_release.md platform="Amazon Linux 2" docker_tag="amazonlinux2" rpm="true"%}
 
 {% include install/_build_snapshot.md platform="Amazon Linux 2"
 aarch64="true"

--- a/install/linux/debian/12/index.md
+++ b/install/linux/debian/12/index.md
@@ -9,4 +9,4 @@ title: Install Swift
 
 {% include install/_os_versions_tabs.md os_versions=site.data.install.debian  name="Debian" pressed="Debian 12" %}
 
-{% include install/_build_release.md platform="Debian 12" docker_tag="debian12" aarch64="true" %}
+{% include install/_build_release.md platform="Debian 12" docker_tag="debian12" %}

--- a/install/linux/fedora/39/index.md
+++ b/install/linux/fedora/39/index.md
@@ -9,4 +9,4 @@ title: Install Swift
 
 {% include install/_os_versions_tabs.md os_versions=site.data.install.fedora  name="Fedora" pressed="Fedora 39" %}
 
-{% include install/_build_release.md platform="Fedora 39" docker_tag="fedora39" aarch64="true" %}
+{% include install/_build_release.md platform="Fedora 39" docker_tag="fedora39" %}

--- a/install/linux/ubi/9/index.md
+++ b/install/linux/ubi/9/index.md
@@ -9,7 +9,7 @@ title: Install Swift
 
 {% include install/_os_versions_tabs.md os_versions=site.data.install.ubi  name="Red Hat Universal Base Image" pressed="Red Hat Universal Base Image 9" %}
 
-{% include install/_build_release.md platform="UBI 9" docker_tag="rhel-ubi9" aarch64="true"%}
+{% include install/_build_release.md platform="UBI 9" docker_tag="rhel-ubi9" %}
 
 {% include install/_build_snapshot.md platform="ubi 9"
 aarch64="true"

--- a/install/linux/ubuntu/20_04/index.md
+++ b/install/linux/ubuntu/20_04/index.md
@@ -9,7 +9,7 @@ title: Install Swift
 
 {% include install/_os_versions_tabs.md os_versions=site.data.install.ubuntu  name="Ubuntu" pressed="Ubuntu 20.04" %}
 
-{% include install/_build_release.md platform="Ubuntu 20.04" docker_tag="focal" aarch64="true"%}
+{% include install/_build_release.md platform="Ubuntu 20.04" docker_tag="focal" %}
 
 {% include install/_build_snapshot.md platform="Ubuntu 20.04"
 aarch64="true"

--- a/install/linux/ubuntu/22_04/index.md
+++ b/install/linux/ubuntu/22_04/index.md
@@ -9,7 +9,7 @@ title: Install Swift
 
 {% include install/_os_versions_tabs.md os_versions=site.data.install.ubuntu  name="Ubuntu" pressed="Ubuntu 22.04" %}
 
-{% include install/_build_release.md platform="Ubuntu 22.04" docker_tag="jammy" aarch64="true"%}
+{% include install/_build_release.md platform="Ubuntu 22.04" docker_tag="jammy" %}
 
 {% include install/_build_snapshot.md platform="Ubuntu 22.04"
 aarch64="true"

--- a/install/linux/ubuntu/24_04/index.md
+++ b/install/linux/ubuntu/24_04/index.md
@@ -9,4 +9,4 @@ title: Install Swift
 
 {% include install/_os_versions_tabs.md os_versions=site.data.install.ubuntu  name="Ubuntu" pressed="Ubuntu 24.04" %}
 
-{% include install/_build_release.md platform="Ubuntu 24.04" docker_tag="noble" aarch64="true"%}
+{% include install/_build_release.md platform="Ubuntu 24.04" docker_tag="noble" %}

--- a/install/windows/index.md
+++ b/install/windows/index.md
@@ -7,6 +7,9 @@ title: Install Swift
 
 ## Latest Release (Swift {{ site.data.builds.swift_releases.last.name }})
 
+{% assign tag = site.data.builds.swift_releases.last.tag %}
+{% assign platform = site.data.builds.swift_releases.last.platforms | where: 'name', 'Windows 10' | first %}
+
 <ul class="install-instruction">
   <li class="resource">
     <h3>Package Manager</h3>
@@ -20,7 +23,11 @@ title: Install Swift
     <p class="description">
       Package installers (.exe).
     </p>
-    <a href="https://download.swift.org/{{ site.data.builds.swift_releases.last.tag | downcase }}/windows10/{{ site.data.builds.swift_releases.last.tag }}/{{ site.data.builds.swift_releases.last.tag }}-windows10.exe" class="cta-secondary">Download (x86_64)</a>
+    <ul class="install-instruction">
+      {% for arch in platform.archs %}
+      <a href="https://download.swift.org/{{ tag | downcase }}/windows10{% if arch != "x86_64" %}-{{ arch }}{% endif %}/{{ tag }}/{{ tag }}-windows10{% if arch != "x86_64" %}-{{ arch }}{% endif %}.exe" class="cta-secondary">Download ({{ arch }})</a>
+      {% endfor %}
+    </ul>
     <a href="/install/windows/traditional" class="cta-secondary">Instructions</a>
   </li>
   <li class="resource">


### PR DESCRIPTION
This PR implements a generic way of detecting multiple archs for the latest release, and add Swift on Windows (arm64) to `swift_releases.yml`.

### Motivation:

`_includes/install/_build_release.md` was relying on a dedicated `include.aarch64` argument for generating an additional link. This is error-prone (eg. we may forget to specify the argument even if an aarch64 toolchain exists), not extensible (eg. if we want to add `riscv64` support we'll then need a new dedicated link) and not future proof (eg. if a new platform doesn't support `x86_64` we'll need a bunch of extra logic).

### Modifications:

`_includes/install/_build_release.md` was partially refactored that:
- drops the `aarch64` input argument;
- detects available archs directly from `swift_releases.yml`;
- removes all special treatment for x86_64 and use unified code for generating all download links.

`install/windows/index.md` was slightly updated to add similar handling for multi-arch.

`_data/builds/swift_releases.yml` was updated to add `arm64` to Swift 6.0 on Windows.

### Result:

Most changes happened internally. The only visible change is that Swift 6.0 toolchain will be available for Windows (arm64).