### PR TITLE
Removed a broken link in the platform steering group page

### DIFF
--- a/platform-steering-group/index.md
+++ b/platform-steering-group/index.md
@@ -26,7 +26,7 @@ The current members of the Platform Steering Group are:
 
 ## Evolution
 
-The Platform Steering Group has [evolution authority](/charter-drafts/steering-group.md#evolution) over low-level tools in the Swift toolchain, including:
+The Platform Steering Group has evolution authority over low-level tools in the Swift toolchain, including:
 
 * The SwiftPM build system
 * The debugger


### PR DESCRIPTION
Removing the broken url from platform steering group page: https://www.swift.org/charter-drafts/steering-group.md

Github issue: https://github.com/swiftlang/swift-org-website/issues/765