### PR TITLE
Fixed platform steering group membership

### DIFF
--- a/_data/contributer-experience-workgroup/emeriti.yml
+++ b/_data/contributer-experience-workgroup/emeriti.yml
@@ -1,0 +1,3 @@
+- name: Max Desiatov
+  github: MaxDesiatov
+  affiliation: 

--- a/_data/contributer-experience-workgroup/members.yml
+++ b/_data/contributer-experience-workgroup/members.yml
@@ -1,0 +1,55 @@
+- name: Alex Hoppen	
+  github: ahoppen
+  affiliation: 
+
+- name: Anthony Latsis	
+  github: AnthonyLatsis
+  affiliation: 
+
+- name: Devanshi Modha	
+  github: devanshimodha
+  affiliation: Diversity in Swift champion
+
+- name: Egor Zhdan
+  github: egorzhdan
+  affiliation: 
+
+- name: Harshita Pathipati	
+  github: harshitapath
+  affiliation: 
+
+- name: Holly Borla	
+  github: hborla
+  affiliation: 
+
+- name: James Dempsey	
+  github: dempseyatgithub
+  affiliation: 
+
+- name: Joseph Heck		
+  github: heckj
+  affiliation: 
+
+- name: Luciano Almeida	
+  github: LucianoPAlmeida
+  affiliation: 
+
+- name: Mishal Shah	
+  github: shahmishal
+  affiliation: 
+
+- name: Paris Pittman	
+  github: parispittman
+  affiliation: 
+
+- name: Pavel Yaskevich
+  github: xedin
+  affiliation: Chair
+
+- name: Suyash Srijan	
+  github: theblixguy
+  affiliation: 
+
+- name: Timirah James	
+  github: timirahj
+  affiliation: 

--- a/_data/language-steering-group/members.yml
+++ b/_data/language-steering-group/members.yml
@@ -1,0 +1,40 @@
+- name: Tony Allevato
+  github: allevato
+  affiliation: 
+  
+- name: Holly Borla
+  github: hborla
+  affiliation: 
+  
+- name: Steve Canon
+  github: stephentyrone
+  affiliation: 
+  
+- name: Ben Cohen
+  github: airspeedswift
+  affiliation: 
+  
+- name: Doug Gregor
+  github: DougGregor
+  affiliation: 
+  
+- name: Joe Groff
+  github: jckarter
+  affiliation: 
+  
+- name: Freddy Kellison-Linn
+  github: Jumhyn
+  affiliation: 
+  
+- name: John McCall
+  github: rjmccall
+  affiliation: Chair
+  
+- name: Becca Royal-Gordon
+  github: beccadax
+  affiliation: 
+  
+- name: Xiaodi Wu
+  github: xwu
+  affiliation: 
+  

--- a/_data/platform-steering-group/members.yml
+++ b/_data/platform-steering-group/members.yml
@@ -1,0 +1,23 @@
+- name: Saleem Abdulrasool
+  github: compnerd
+  affiliation: Core Team Representative & member
+
+- name: Alastair Houghton
+  github: al45tair
+  affiliation: Chair
+
+- name: Danielle Lancashire
+  github: endocrimes
+  affiliation: 
+
+- name: Frederic Riss
+  github: fredriss
+  affiliation:
+
+- name: Kuba Mracek
+  github: kubamracek
+  affiliation: 
+
+- name: Rokhini Prabhu
+  github: rokhinip
+  affiliation: 

--- a/contributor-experience-workgroup/index.md
+++ b/contributor-experience-workgroup/index.md
@@ -31,92 +31,35 @@ Members of the workgroup serve at the discretion of the Swift Core Team and the 
 
 The current members of the workgroup are:
 
-<table>
-  <thead>
-    <tr>
-      <th>Member</th>
-      <th>Swift forums</th>
-      <th>GitHub</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Alex Hoppen</td>
-      <td><a href="https://forums.swift.org/u/ahoppen">@ahoppen</a></td>
-      <td><a href="https://github.com/ahoppen">@ahoppen</a></td>
-    </tr>
-    <tr>
-      <td>Anthony Latsis</td>
-      <td><a href="https://forums.swift.org/u/anthonylatsis">@anthonylatsis</a></td>
-      <td><a href="https://github.com/AnthonyLatsis">@AnthonyLatsis</a></td>
-    </tr>
-    <tr>
-      <td>Devanshi Modha (Diversity in Swift champion)</td>
-      <td><a href="https://forums.swift.org/u/devanshimodha">@devanshimodha</a></td>
-      <td><a href="https://github.com/devanshimodha">@devanshimodha</a></td>
-    </tr>
-    <tr>
-      <td>Egor Zhdan</td>
-      <td><a href="https://forums.swift.org/u/egor.zhdan">@egor.zhdan</a></td>
-      <td><a href="https://github.com/egorzhdan">@egorzhdan</a></td>
-    </tr>
-    <tr>
-      <td>Harshita Pathipati</td>
-      <td><a href="https://forums.swift.org/u/hpathipati">@hpathipati</a></td>
-      <td><a href="https://github.com/harshitapath">@harshitapath</a></td>
-    </tr>
-    <tr>
-      <td>Holly Borla</td>
-      <td><a href="https://forums.swift.org/u/hborla">@hborla</a></td>
-      <td><a href="https://github.com/hborla">@hborla</a></td>
-    </tr>
-    <tr>
-      <td>James Dempsey</td>
-      <td><a href="https://forums.swift.org/u/James_Dempsey">@James_Dempsey</a></td>
-      <td><a href="https://github.com/dempseyatgithub">@dempseyatgithub</a></td>
-    </tr>
-    <tr>
-      <td>Joseph Heck</td>
-      <td><a href="https://forums.swift.org/u/Joseph_Heck">@Joseph_Heck</a></td>
-      <td><a href="https://github.com/heckj">@heckj</a></td>
-    </tr>
-    <tr>
-      <td>Luciano Almeida</td>
-      <td><a href="https://forums.swift.org/u/LucianoPAlmeida">@LucianoPAlmeida</a></td>
-      <td><a href="https://github.com/LucianoPAlmeida">@LucianoPAlmeida</a></td>
-    </tr>
-    <tr>
-      <td>Mishal Shah</td>
-      <td><a href="https://forums.swift.org/u/mishal_shah">@mishal_shah</a></td>
-      <td><a href="https://github.com/shahmishal">@shahmishal</a></td>
-    </tr>
-    <tr>
-      <td>Paris Pittman</td>
-      <td><a href="https://forums.swift.org/u/parispittman">@parispittman</a></td>
-      <td><a href="https://github.com/parispittman">@parispittman</a></td>
-    </tr>
-    <tr>
-      <td>Pavel Yaskevich (chair)</td>
-      <td><a href="https://forums.swift.org/u/xedin">@xedin</a></td>
-      <td><a href="https://github.com/xedin">@xedin</a></td>
-    </tr>
-    <tr>
-      <td>Suyash Srijan</td>
-      <td><a href="https://forums.swift.org/u/suyashsrijan">@suyashsrijan</a></td>
-      <td><a href="https://github.com/theblixguy">@theblixguy</a></td>
-    </tr>
-    <tr>
-      <td>Timirah James</td>
-      <td><a href="https://forums.swift.org/u/timirahj">@timirahj</a></td>
-      <td><a href="https://github.com/timirahj">@timirahj</a></td>
-    </tr>
-  </tbody>
-</table>
+{% assign people = site.data['contributer-experience-workgroup'].members | sort: "name" %}
+<ul>
+{% for person in people %}
+<li>{{ person.name }}
+{%- if person.affiliation -%}
+  , {{ person.affiliation }}
+{% endif %}
+{% if person.github %}
+  (<a href="https://github.com/{{person.github}}">@{{person.github}}</a>)
+{% endif %}
+</li>
+{% endfor %}
+</ul>
 
 We are grateful for the service of the following emeritus workgroup member:
 
-* [Max Desiatov](https://github.com/MaxDesiatov)
-
+{% assign people = site.data['contributer-experience-workgroup'].emeriti | sort: "name" %}
+<ul>
+{% for person in people %}
+<li>{{ person.name }}
+{%- if person.affiliation -%}
+  , {{ person.affiliation }}
+{% endif %}
+{% if person.github %}
+  (<a href="https://github.com/{{person.github}}">@{{person.github}}</a>)
+{% endif %}
+</li>
+{% endfor %}
+</ul>
 
 ## Communication
 

--- a/language-steering-group/index.md
+++ b/language-steering-group/index.md
@@ -33,16 +33,19 @@ The Core Team also selects one member of the workgroup as the chair. The chair h
 
 The current members of the Language Steering Group are:
 
-* [Tony Allevato](https://github.com/allevato/)
-* [Holly Borla](https://github.com/hborla/)
-* [Steve Canon](https://github.com/stephentyrone/)
-* [Ben Cohen](https://github.com/airspeedswift/)
-* [Doug Gregor](https://github.com/DougGregor/)
-* [Joe Groff](https://github.com/jckarter/)
-* [Freddy Kellison-Linn](https://github.com/Jumhyn/)
-* [John McCall](https://github.com/rjmccall/) (chair)
-* [Becca Royal-Gordon](https://github.com/beccadax/)
-* [Xiaodi Wu](https://github.com/xwu/)
+{% assign people = site.data['language-steering-group'].members | sort: "name" %}
+<ul>
+{% for person in people %}
+<li>{{ person.name }}
+{%- if person.affiliation -%}
+  , {{ person.affiliation }}
+{% endif %}
+{% if person.github %}
+  (<a href="https://github.com/{{person.github}}">@{{person.github}}</a>)
+{% endif %}
+</li>
+{% endfor %}
+</ul>
 
 ## Decision making
 

--- a/platform-steering-group/index.md
+++ b/platform-steering-group/index.md
@@ -17,12 +17,20 @@ The Platform Steering Group is made up of Swift community members who have techn
 
 The current members of the Platform Steering Group are:
 
-* [Saleem Abdulrasool](https://github.com/compnerd) (Core Team Representative & member)
-* [Alastair Houghton](https://github.com/al45tair) (chair)
-* [Danielle Lancashire](https://github.com/endocrimes)
-* [Frederic Riss](https://github.com/fredriss)
-* [Kuba Mracek](https://github.com/kubamracek)
-* [Rokhini Prabhu](https://github.com/rokhinip)
+{% assign people = site.data['platform-steering-group'].members | sort: "name" %}
+<ul>
+{% for person in people %}
+<li>{{ person.name }}
+{%- if person.affiliation -%}
+  , {{ person.affiliation }}
+{% endif %}
+{% if person.github %}
+  (<a href="https://github.com/{{person.github}}">@{{person.github}}</a>)
+{% endif %}
+</li>
+{% endfor %}
+</ul>
+
 
 ## Evolution
 


### PR DESCRIPTION
Refactoring the hardcoded members list into yml file on platform steering group page: https://www.swift.org/platform-steering-group/
