### PR TITLE
[6.0] Add Docker images to the install page

### DIFF
--- a/_data/builds/swift_releases.yml
+++ b/_data/builds/swift_releases.yml
@@ -1761,53 +1761,56 @@
   platforms:
     - name: Ubuntu 20.04
       platform: Linux
-      docker: Coming Soon #6.0-focal
+      docker: 6.0-focal
       archs:
         - x86_64
         - aarch64
     - name: Ubuntu 22.04
       platform: Linux
-      docker: Coming Soon #6.0-jammy
+      docker: 6.0-jammy
       archs:
         - x86_64
         - aarch64
     - name: Ubuntu 24.04
       platform: Linux
-      docker: Coming Soon #6.0-noble
+      docker: 6.0-noble
       archs:
         - x86_64
         - aarch64
     - name: Debian 12
       platform: Linux
-      docker: Coming Soon #6.0-bookworm
+      docker: 6.0-bookworm
       archs:
         - x86_64
         - aarch64
     - name: Fedora 39
       platform: Linux
-      docker: Coming Soon #6.0-fedora39
+      docker: 6.0-fedora39
       archs:
         - x86_64
         - aarch64
     - name: Amazon Linux 2
       platform: Linux
-      docker: Coming Soon #6.0-amazonlinux2
+      docker: 6.0-amazonlinux2
       archs:
         - x86_64
         - aarch64
     - name: Red Hat Universal Base Image 9
       platform: Linux
-      docker: Coming Soon #6.0-rhel-ubi9
+      docker: 6.0-rhel-ubi9
       dir: ubi9
       archs:
         - x86_64
         - aarch64
     - name: Windows 10
       platform: Windows
-      docker: Coming Soon #6.0-windowsservercore-ltsc2022
+      docker: 6.0-windowsservercore-ltsc2022
       archs:
         - x86_64
         - arm64
     - name: Static SDK
       platform: static-sdk
       checksum: 7984c2cf175bde52ba6ea1fcbe27fc4a148a6237c41c719209c9288ed3ceb652
+      archs:
+        - x86_64
+        - arm64

--- a/_includes/install/_build_release.md
+++ b/_includes/install/_build_release.md
@@ -15,7 +15,7 @@
     <p class="description">
       The offical Docker images for Swift.
     </p>
-    <a href="https://hub.docker.com/_/swift" class="cta-secondary external">Coming Soon</a>
+    <a href="https://hub.docker.com/_/swift" class="cta-secondary external">{{ site.data.builds.swift_releases.last.name }}-{{include.docker_tag}}</a>
     <a href="/install/linux/docker" class="cta-secondary">Instructions</a>
   </li>
   <li class="grid-level-1">

--- a/install/windows/index.md
+++ b/install/windows/index.md
@@ -42,7 +42,7 @@ title: Install Swift
     <p class="description">
       The offical Docker images for Swift.
     </p>
-    <a href="https://hub.docker.com/_/swift" class="cta-secondary external">Coming Soon</a>
+    <a href="https://hub.docker.com/_/swift" class="cta-secondary external">{{ site.data.builds.swift_releases.last.name }}-windowsservercore-ltsc2022</a>
   </li>
 </ul>
 


### PR DESCRIPTION
hub.docker.com images are now available. 