### PR TITLE
Fix two H1 tags on language steering group page

### DIFF
--- a/language-steering-group/index.md
+++ b/language-steering-group/index.md
@@ -5,7 +5,7 @@ title: Language Steering Group
 
 The Swift Language Steering Group guides the development of the Swift language and standard libraries through the [Swift evolution process](https://github.com/swiftlang/swift-evolution/blob/main/process.md).
 
-# Charter
+## Charter
 
 The Swift Language Steering Group:
 * works with the [Swift Core Team](/community/#community-structure) to define a roadmap for the focus areas of language and library development in the upcoming releases of Swift.


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

There should only be a single H1 per page. It also applies the wrong hierarchical styling.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Changed the Charter H1 to an H2

### Result:

<!-- _[After your change, what will change.]_ -->

|Before|After
|---|---|
|![CleanShot 2024-09-18 at 09 57 05](https://github.com/user-attachments/assets/c987f734-3b3b-46b9-8820-09fc292b1e4e)|![CleanShot 2024-09-18 at 09 57 25](https://github.com/user-attachments/assets/5c7b4f80-0a29-43da-9e84-31994a2fa909)|