### PR TITLE
update dead link to Platform Category Forum in index.md

### DIFF
--- a/platform-steering-group/index.md
+++ b/platform-steering-group/index.md
@@ -60,7 +60,7 @@ Not all changes driven by the Platform Steering Group will under go evolution re
 
 ## Communication
 
-The Platform Steering Group communicates with the community primarily using the [Platform category](https://forums.swift.org/c/platform) on the Swift forums.  It may also prepare special posts for the [Swift Blog](https://www.swift.org/blog/).
+The Platform Steering Group communicates with the community primarily using the [Platform category](https://forums.swift.org/t/platform-steering-group/) on the Swift forums.  It may also prepare special posts for the [Swift Blog](https://www.swift.org/blog/).
 
 The Steering Group is presently working on a process for platform evolution and will update this charter when details of this process have been finalised, but it is expected that the Steering Group will be responsible for:
 


### PR DESCRIPTION
Replace the old dead link which 404s with a new link that points to the platform-steering-group form page

### Motivation:
I want to fix [PR-765](https://github.com/swiftlang/swift-org-website/issues/765 so we don't have dead links on the website anymore  


### Modifications:
https://forums.swift.org/c/platform
got replaced by
https://forums.swift.org/t/platform-steering-group/

### Result:
Now the link is not dead anymore
