### PR TITLE
Add placeholder API for swiftly releases

### DIFF
--- a/_data/builds/swiftly_release.yml
+++ b/_data/builds/swiftly_release.yml
@@ -1,0 +1,8 @@
+version: "0.3.0"
+platforms:
+  - platform: Linux
+    x86_64: "https://download.swift.org/swiftly-0.3.0-release/linux/swiftly-0.3.0-RELEASE/swiftly-0.3.0-RELEASE-linux.tar.gz"
+    arm64: "https://download.swift.org/swiftly-0.3.0-release/linux-aarch64/swiftly-0.3.0-RELEASE/swiftly-0.3.0-RELEASE-linux-aarch64.tar.gz"
+  - platform: Darwin
+    x86_64: "https://download.swift.org/swiftly-0.3.0-release/darwin/swiftly-0.3.0-RELEASE/swiftly-0.3.0-RELEASE-darwin.pkg"
+    arm64: "https://download.swift.org/swiftly-0.3.0-release/darwin/swiftly-0.3.0-RELEASE/swiftly-0.3.0-RELEASE-darwin.pkg"

--- a/_data/builds/swiftly_release.yml
+++ b/_data/builds/swiftly_release.yml
@@ -1,8 +1,8 @@
 version: "0.4.0-dev"
 platforms:
   - platform: Linux
-    x86_64: "https://download.swift.org/swiftly-0.4.0-dev/linux/swiftly-0.4.0-dev-x86_64.tar.gz"
-    arm64: "https://download.swift.org/swiftly-0.4.0-dev/linux/swiftly-0.4.0-dev-aarch64.tar.gz"
+    x86_64: "https://download.swift.org/linux/swiftly-0.4.0-dev-x86_64.tar.gz"
+    arm64: "https://download.swift.org/linux/swiftly-0.4.0-dev-aarch64.tar.gz"
   - platform: Darwin
-    x86_64: "https://download.swift.org/swiftly-0.4.0-dev/darwin/swiftly-0.4.0-dev.pkg"
-    arm64: "https://download.swift.org/swiftly-0.4.0-dev/darwin/swiftly-0.4.0-dev.pkg"
+    x86_64: "https://download.swift.org/darwin/swiftly-0.4.0-dev.pkg"
+    arm64: "https://download.swift.org/darwin/swiftly-0.4.0-dev.pkg"

--- a/_data/builds/swiftly_release.yml
+++ b/_data/builds/swiftly_release.yml
@@ -1,8 +1,8 @@
-version: "0.3.0"
+version: "0.4.0-dev"
 platforms:
   - platform: Linux
-    x86_64: "https://download.swift.org/swiftly-0.3.0-release/linux/swiftly-0.3.0-RELEASE/swiftly-0.3.0-RELEASE-linux.tar.gz"
-    arm64: "https://download.swift.org/swiftly-0.3.0-release/linux-aarch64/swiftly-0.3.0-RELEASE/swiftly-0.3.0-RELEASE-linux-aarch64.tar.gz"
+    x86_64: "https://download.swift.org/swiftly-0.4.0-dev-release/linux/swiftly-0.4.0-dev-RELEASE/swiftly-0.4.0-dev.tar.gz"
+    arm64: "https://download.swift.org/swiftly-0.4.0-dev-release/linux-aarch64/swiftly-0.4.0-dev-RELEASE/swiftly-0.4.0-dev-aarch64.tar.gz"
   - platform: Darwin
-    x86_64: "https://download.swift.org/swiftly-0.3.0-release/darwin/swiftly-0.3.0-RELEASE/swiftly-0.3.0-RELEASE-darwin.pkg"
-    arm64: "https://download.swift.org/swiftly-0.3.0-release/darwin/swiftly-0.3.0-RELEASE/swiftly-0.3.0-RELEASE-darwin.pkg"
+    x86_64: "https://download.swift.org/swiftly-0.4.0-dev-release/darwin/swiftly-0.4.0-dev-RELEASE/swiftly-0.4.0-dev.pkg"
+    arm64: "https://download.swift.org/swiftly-0.4.0-dev-release/darwin/swiftly-0.4.0-dev-RELEASE/swiftly-0.4.0-dev.pkg"

--- a/_data/builds/swiftly_release.yml
+++ b/_data/builds/swiftly_release.yml
@@ -1,8 +1,8 @@
 version: "0.4.0-dev"
 platforms:
   - platform: Linux
-    x86_64: "https://download.swift.org/swiftly-0.4.0-dev-release/linux/swiftly-0.4.0-dev-RELEASE/swiftly-0.4.0-dev.tar.gz"
-    arm64: "https://download.swift.org/swiftly-0.4.0-dev-release/linux-aarch64/swiftly-0.4.0-dev-RELEASE/swiftly-0.4.0-dev-aarch64.tar.gz"
+    x86_64: "https://download.swift.org/swiftly-0.4.0-dev/linux/swiftly-0.4.0-dev-x86_64.tar.gz"
+    arm64: "https://download.swift.org/swiftly-0.4.0-dev/linux/swiftly-0.4.0-dev-aarch64.tar.gz"
   - platform: Darwin
-    x86_64: "https://download.swift.org/swiftly-0.4.0-dev-release/darwin/swiftly-0.4.0-dev-RELEASE/swiftly-0.4.0-dev.pkg"
-    arm64: "https://download.swift.org/swiftly-0.4.0-dev-release/darwin/swiftly-0.4.0-dev-RELEASE/swiftly-0.4.0-dev.pkg"
+    x86_64: "https://download.swift.org/swiftly-0.4.0-dev/darwin/swiftly-0.4.0-dev.pkg"
+    arm64: "https://download.swift.org/swiftly-0.4.0-dev/darwin/swiftly-0.4.0-dev.pkg"

--- a/_data/builds/swiftly_release.yml
+++ b/_data/builds/swiftly_release.yml
@@ -1,8 +1,8 @@
 version: "0.4.0-dev"
 platforms:
   - platform: Linux
-    x86_64: "https://download.swift.org/linux/swiftly-0.4.0-dev-x86_64.tar.gz"
-    arm64: "https://download.swift.org/linux/swiftly-0.4.0-dev-aarch64.tar.gz"
+    x86_64: "https://download.swift.org/swiftly/linux/swiftly-0.4.0-dev-x86_64.tar.gz"
+    arm64: "https://download.swift.org/swiftly/linux/swiftly-0.4.0-dev-aarch64.tar.gz"
   - platform: Darwin
-    x86_64: "https://download.swift.org/darwin/swiftly-0.4.0-dev.pkg"
-    arm64: "https://download.swift.org/darwin/swiftly-0.4.0-dev.pkg"
+    x86_64: "https://download.swift.org/swiftly/darwin/swiftly-0.4.0-dev.pkg"
+    arm64: "https://download.swift.org/swiftly/darwin/swiftly-0.4.0-dev.pkg"

--- a/api/v1/swiftly.json
+++ b/api/v1/swiftly.json
@@ -1,15 +1,4 @@
-{
-    "version": "0.3.0",
-    "platforms": [
-        {
-            "platform": "Darwin",
-            "x86_64": "https://download.swift.org/swiftly-0.3.0-release/darwin/swiftly-0.3.0-RELEASE/swiftly-0.3.0-RELEASE-darwin.pkg",
-            "arm64": "https://download.swift.org/swiftly-0.3.0-release/darwin/swiftly-0.3.0-RELEASE/swiftly-0.3.0-RELEASE-darwin.pkg"
-        },
-        {
-            "platform": "Linux",
-            "x86_64": "https://download.swift.org/swiftly-0.3.0-release/linux/swiftly-0.3.0-RELEASE/swiftly-0.3.0-RELEASE-linux.tar.gz",
-            "arm64": "https://download.swift.org/swiftly-0.3.0-release/linux-aarch64/swiftly-0.3.0-RELEASE/swiftly-0.3.0-RELEASE-linux-aarch64.tar.gz"
-        }
-    ]
-}
+---
+layout: none
+---
+{{ site.data.builds.swiftly_release | jsonify }}

--- a/api/v1/swiftly.json
+++ b/api/v1/swiftly.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.3.0",
+    "platforms": [
+        {
+            "platform": "Darwin",
+            "x86_64": "https://download.swift.org/swiftly-0.3.0-release/darwin/swiftly-0.3.0-RELEASE/swiftly-0.3.0-RELEASE-darwin.pkg",
+            "arm64": "https://download.swift.org/swiftly-0.3.0-release/darwin/swiftly-0.3.0-RELEASE/swiftly-0.3.0-RELEASE-darwin.pkg"
+        },
+        {
+            "platform": "Linux",
+            "x86_64": "https://download.swift.org/swiftly-0.3.0-release/linux/swiftly-0.3.0-RELEASE/swiftly-0.3.0-RELEASE-linux.tar.gz",
+            "arm64": "https://download.swift.org/swiftly-0.3.0-release/linux-aarch64/swiftly-0.3.0-RELEASE/swiftly-0.3.0-RELEASE-linux-aarch64.tar.gz"
+        }
+    ]
+}


### PR DESCRIPTION
As pitched in the forum this is a preliminary API providing metadata about the currently available swiftly release. https://forums.swift.org/t/new-swift-org-api-endpoint-for-the-current-swiftly-release/74702

### Motivation:

Swiftly itself has a self-update mechanism to help provide an easy path to keep in sync with the capability of the swift.org website, and to roll out new features and bug fixes. Since swift.org is the place where the official swiftly releases will be published then this API is updated whenever there is a new release. Since there has not yet been a swiftly release on swift.org and existing swiftly installations do not yet use this new API mechanism, there are no expected clients of this API yet. This is a preliminary step to prepare for a release of swiftly when that does happen.

### Modifications:

Added a new /api/v1/swiftly.json endpoint with metadata about the current swiftly release, for now, until the next swiftly is released.

### Result:

As a result, this endpoint will be accessible to swiftly when it is released.