### PR TITLE
Update links to VS Code Swift in the getting started guide

### DIFF
--- a/documentation/articles/getting-started-with-vscode-swift.md
+++ b/documentation/articles/getting-started-with-vscode-swift.md
@@ -250,4 +250,4 @@ The Swift for Visual Studio Code extension is a community driven project origina
 created by the [Swift Server Working Group](https://www.swift.org/sswg/) and now
 maintained as part of the [swiftlang organization](https://github.com/swiftlang/).
 Contributions are appreciated, including code, tests and documentation. For more
-details please visit the [GitHub repository for VS Code Swift](https://github.com/swiftlang/vscode-swift)
+details please visit the [Swift for VS Code extension repository](https://github.com/swiftlang/vscode-swift)

--- a/documentation/articles/getting-started-with-vscode-swift.md
+++ b/documentation/articles/getting-started-with-vscode-swift.md
@@ -30,7 +30,7 @@ The Swift extension is designed to support the following projects:
    [Getting Started Guide on Swift.org](/getting-started/).
 2. Download and install [Visual Studio Code](https://code.visualstudio.com/Download).
 3. Install the Swift extension from the
-   [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sswg.swift-lang)
+   [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=swiftlang.vscode-swift)
    or directly from within the VS Code extensions pane.
 
 ![Installing the vscode-swift extension from the extensions pane](/assets/images/getting-started-with-vscode-swift/installation.png)
@@ -246,5 +246,8 @@ function correctly:
 
 ## Contributors
 
-The extension is developed by members of the Swift Community and maintained by
-the [Swift Server Working Group](/sswg/).
+The Swift for Visual Studio Code extension is a community driven project originally
+created by the [Swift Server Working Group](https://www.swift.org/sswg/) and now
+maintained as part of the [swiftlang organization](https://github.com/swiftlang/).
+Contributions are appreciated, including code, tests and documentation. For more
+details please visit the [GitHub repository for VS Code Swift](https://github.com/swiftlang/vscode-swift)


### PR DESCRIPTION
Update the links to VS Code Swift in the getting started guide for VS Code.

### Motivation:

The Swift extension for Visual Studio Code will be moving under a new swiftlang organization created within the [VS Code Marketplace](https://marketplace.visualstudio.com/vscode). This means that the installation instructions in the getting started guide will soon be out of date.

### Modifications:

I've modified the links in the getting started guide to point at the new extension and updated the contributors section to point out how the extension is now managed by the swiftlang organization.

### Result:

The getting started guide for VS Code will point to the new location that the official extension will be installed from. However, this change will have to wait until the extension is officially published before it can be merged. This will happen sometime next week.
