### PR TITLE
[install] Add Swiftly to the install page under beta/preview

### DIFF
--- a/_includes/install/_linux_platforms_tabs.md
+++ b/_includes/install/_linux_platforms_tabs.md
@@ -1,3 +1,23 @@
+## Toolchain Installer
+<ul class="grid-level-0">
+<li class="grid-level-1 featured">
+    <h3>Swiftly (beta)</h3>
+  <p class="description">
+    Command line tool for installing, managing, and switching between Swift.org toolchains.
+  </p>
+  <!-- <br>
+  <p>To install swiftly, run the following command in your terminal.</p>
+  <pre><code>
+  $ curl -s https://download.swift.org/linux/swiftly > /usr/local/bin/swiftly
+  </code></pre> -->
+  <h4>License: <a href="https://raw.githubusercontent.com/swiftlang/swiftly/refs/heads/main/LICENSE.txt">Apache-2.0</a> | PGP: <a href="https://download.swift.org/linux/swiftly.sig">Signature</a></h4>
+  <a href="https://download.swift.org/linux/swiftly" class="cta-secondary">Download</a>
+  <a href="/install/linux/swiftly" class="cta-secondary">Instructions</a>
+</li>
+</ul>
+
+## Alternate installation options
+
 <p id="platforms">Select Linux platform:</p>
 
 <div class="interactive-tabs os">

--- a/install/linux/index.md
+++ b/install/linux/index.md
@@ -4,5 +4,4 @@ title: Install Swift
 ---
 
 {% include install/_os_tabs.md linux="true" %}
-
 {% include install/_linux_platforms_tabs.md %}

--- a/install/linux/swiftly/index.md
+++ b/install/linux/swiftly/index.md
@@ -1,0 +1,48 @@
+---
+layout: page
+title: Getting Started with Swiftly
+---
+
+Download swiftly from the [install page](/install).
+
+Run the following command in your terminal, to configure swiftly for your account:
+
+```
+$ swiftly init
+```
+
+Once swiftly is installed you can use it to install the latest available swift toolchain like this:
+
+```
+$ swiftly install latest
+
+Fetching the latest stable Swift release...
+Installing Swift 6.0.1
+Downloaded 488.5 MiB of 488.5 MiB
+Extracting toolchain...
+Swift 6.0.1 installed successfully!
+
+$ swift --version
+
+Swift version 6.0.1 (swift-6.0.1-RELEASE)
+Target: x86_64-unknown-linux-gnu
+```
+
+Or, you can install (and use) a swift release:
+
+```
+$ swiftly install --use 5.10
+
+$ swift --version
+
+Swift version 5.10 (swift-5.10-RELEASE)
+Target: x86_64-unknown-linux-gnu
+```
+
+There's also an option to install the latest snapshot release and get access to the latest features:
+
+```
+$ swiftly install main-snapshot
+```
+
+> Note: This last example just installed the toolchain. You can run "swiftly use" to switch to it and other installed toolchahins when you're ready.

--- a/install/macos/index.md
+++ b/install/macos/index.md
@@ -5,8 +5,19 @@ title: Install Swift
 
 {% include install/_os_tabs.md macos="true" %}
 
-## Latest Release (Swift {{ site.data.builds.swift_releases.last.name }})
+## Toolchain Installer
+<ul class="grid-level-0">
+<li class="grid-level-1 featured">
+    <h3>Swiftly (beta)</h3>
+  <p class="description">
+    Command line tool for installing, managing, and switching between Swift.org toolchains.
+  </p>
+  <a href="https://download.swift.org/macos/swiftly.pkg" class="cta-secondary">Download</a>
+  <a href="/install/macos/swiftly" class="cta-secondary">Instructions</a>
+</li>
+</ul>
 
+## Latest Release (Swift {{ site.data.builds.swift_releases.last.name }})
 <ul class="grid-level-0 grid-layout-2-column">
   <li class="grid-level-1">
     <h3>Xcode</h3>

--- a/install/macos/swiftly/index.md
+++ b/install/macos/swiftly/index.md
@@ -1,0 +1,51 @@
+---
+layout: page
+title: Getting Started with Swiftly
+---
+
+Download swiftly from the [install page](/install).
+
+Run the following command in your terminal, to configure swiftly for your account:
+
+```
+$ swiftly init
+```
+
+Once swiftly is installed you can use it to install the latest available swift toolchain like this:
+
+```
+$ swiftly install latest
+
+Fetching the latest stable Swift release...
+Installing Swift 6.0.1
+Downloaded 1355.3 MiB of 1355.3 MiB
+Installing package in user home directory...
+installer: Package name is Swift Open Source Xcode Toolchain
+installer: Upgrading at base path /Users/swift
+installer: The upgrade was successful.
+Swift 6.0.1 installed successfully!
+
+$ swift --version
+
+Apple Swift version 6.0.1 (swift-6.0.1-RELEASE)
+Target: arm64-apple-macosx15.0
+```
+
+Or, you can install (and use) a swift release:
+
+```
+$ swiftly install --use 5.10
+
+$ swift --version
+
+Apple Swift version 5.10 (swift-5.10-RELEASE)
+Target: arm64-apple-macosx15.0
+```
+
+There's also an option to install the latest snapshot release and get access to the latest features:
+
+```
+$ swiftly install main-snapshot
+```
+
+> Note: This last example just installed the toolchain. You can run "swiftly use" to switch to it and other installed toolchahins when you're ready.


### PR DESCRIPTION
Bring swiftly to swift.org install page under beta/preview. 

### Linux
<img width="1494" alt="Screenshot 2024-10-18 at 12 17 55 AM" src="https://github.com/user-attachments/assets/1aeb984c-61ea-4ae7-9e23-41c29c7d6c90">

### macOS
<img width="1487" alt="Screenshot 2024-10-18 at 12 17 43 AM" src="https://github.com/user-attachments/assets/72ae8c6d-f8b7-4b23-a1a3-e39e92d5a770">
