### PR TITLE
Windows: add ARM64 MSVC Tools to VS installation

### DIFF
--- a/install/windows/_scoop.md
+++ b/install/windows/_scoop.md
@@ -26,7 +26,7 @@ Invoke-RestMethod get.scoop.sh | Invoke-Expression
 
    ~~~ batch
    curl -sOL https://aka.ms/vs/17/release/vs_community.exe
-   start /w vs_community.exe --passive --wait --norestart --nocache --add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+   start /w vs_community.exe --passive --wait --norestart --nocache --add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64
    del /q vs_community.exe
    ~~~
 

--- a/install/windows/_winget.md
+++ b/install/windows/_winget.md
@@ -9,7 +9,7 @@
    Install the latest MSVC toolset and Windows 11 SDK (10.0.22000) through Visual Studio 2022 Community installer. You may change the Visual Studio edition depending on your usage and team size.
 
    ~~~ batch
-   winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
+   winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64"
    ~~~
 
 0. Install Swift and other dependencies:

--- a/install/windows/scoop/index.md
+++ b/install/windows/scoop/index.md
@@ -29,7 +29,7 @@ Invoke-RestMethod get.scoop.sh | Invoke-Expression
 
    ~~~ batch
    curl -sOL https://aka.ms/vs/17/release/vs_community.exe
-   start /w vs_community.exe --passive --wait --norestart --nocache --add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+   start /w vs_community.exe --passive --wait --norestart --nocache --add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64
    del /q vs_community.exe
    ~~~
 

--- a/install/windows/winget/index.md
+++ b/install/windows/winget/index.md
@@ -14,7 +14,7 @@ title: Installation via Windows Package Manager
    Install the latest MSVC toolset and Windows 11 SDK (10.0.22000) through Visual Studio 2022 Community installer. You may change the Visual Studio edition depending on your usage and team size.
 
    ~~~ batch
-   winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
+   winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64"
    ~~~
 
 0. Install Swift and other dependencies:


### PR DESCRIPTION
Instruct users to install the MSVC ARM64 tools when installing Visual Studio. This should ensure that cross-compilation is possible (and native compilation when on ARM64).

Fixes: #839