### PR TITLE
Harmonize VS Dependency language across Windows install pages

### DIFF
--- a/install/windows/_scoop.md
+++ b/install/windows/_scoop.md
@@ -16,9 +16,9 @@ Invoke-RestMethod get.scoop.sh | Invoke-Expression
    scoop install python39
    ~~~
 
-0. Install platform dependencies:
+0. Install Windows platform dependencies:
 
-   The platform dependencies cannot be installed through Scoop as the install rules cannot install all required components. They will be installed through the Visual Studio 2022 Community installer. You may change the Visual Studio edition depending on your usage and team size.
+   The required C++ toolchain and Windows SDK are installed as part of Visual Studio 2022. The instructions below are for the Community edition, but you may want to [use a different Visual Studio edition](https://visualstudio.microsoft.com/vs/compare/) based on your usage and team size.
 
    <div class="warning" markdown="1">
    This code snippet must be run in a traditional Command Prompt (`cmd.exe`).

--- a/install/windows/_winget.md
+++ b/install/windows/_winget.md
@@ -4,9 +4,9 @@
 
 0. Setup all needed [dependencies](/install/windows/#dependencies).
 
-0. Install required Visual Studio components:
+0. Install Windows platform dependencies:
 
-   Install the latest MSVC toolset and Windows 11 SDK (10.0.22000) through Visual Studio 2022 Community installer. You may change the Visual Studio edition depending on your usage and team size.
+   The required C++ toolchain and Windows SDK are installed as part of Visual Studio 2022. The instructions below are for the Community edition, but you may want to [use a different Visual Studio edition](https://visualstudio.microsoft.com/vs/compare/) based on your usage and team size.
 
    ~~~ batch
    winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64"
@@ -14,7 +14,7 @@
 
 0. Install Swift and other dependencies:
 
-   Install the latest Swift developer package, as well as compatible Git and Python tools if they don't exist.
+   Install the latest Swift developer package, as well as compatible Git and Python tools if necessary.
 
    ~~~ batch
    winget install --id Swift.Toolchain -e

--- a/install/windows/scoop/index.md
+++ b/install/windows/scoop/index.md
@@ -19,9 +19,9 @@ Invoke-RestMethod get.scoop.sh | Invoke-Expression
    scoop install python39
    ~~~
 
-0. Install platform dependencies:
+0. Install Windows platform dependencies:
 
-   The platform dependencies cannot be installed through Scoop as the install rules cannot install all required components. They will be installed through the Visual Studio 2022 Community installer. You may change the Visual Studio edition depending on your usage and team size.
+   The required C++ toolchain and Windows SDK are installed as part of Visual Studio 2022. The instructions below are for the Community edition, but you may want to [use a different Visual Studio edition](https://visualstudio.microsoft.com/vs/compare/) based on your usage and team size.
 
    <div class="warning" markdown="1">
    This code snippet must be run in a traditional Command Prompt (`cmd.exe`).

--- a/install/windows/winget/index.md
+++ b/install/windows/winget/index.md
@@ -9,9 +9,9 @@ title: Installation via Windows Package Manager
 
    In order to develop applications, particularly with the Swift Package Manager, you will need to enable developer mode. Please see Microsoft’s [documentation](https://docs.microsoft.com/windows/apps/get-started/enable-your-device-for-development) for instructions about how to enable developer mode.
 
-0. Install required Visual Studio components:
+0. Install Windows platform dependencies:
 
-   Install the latest MSVC toolset and Windows 11 SDK (10.0.22000) through Visual Studio 2022 Community installer. You may change the Visual Studio edition depending on your usage and team size.
+   The required C++ toolchain and Windows SDK are installed as part of Visual Studio 2022. The instructions below are for the Community edition, but you may want to [use a different Visual Studio edition](https://visualstudio.microsoft.com/vs/compare/) based on your usage and team size.
 
    ~~~ batch
    winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64"


### PR DESCRIPTION
Reduce inconsistencies between the various Windows pages around installing the VS dependencies. Also include a link to the VS editions page to make sure that it's clearer when you need to install a paid SKU.