### PR TITLE
Add SSWG package collections

### DIFF
--- a/_data/server-workgroup/graduated.yml
+++ b/_data/server-workgroup/graduated.yml
@@ -1,0 +1,12 @@
+- https://github.com/apple/swift-crypto.git
+- https://github.com/apple/swift-log.git
+- https://github.com/apple/swift-metrics.git
+- https://github.com/apple/swift-nio.git
+- https://github.com/apple/swift-statsd-client.git
+- https://github.com/grpc/grpc-swift.git
+- https://github.com/swift-server-community/APNSwift.git
+- https://github.com/swift-server/async-http-client.git
+- https://github.com/vapor/jwt-kit.git
+- https://github.com/vapor/multipart-kit.git
+- https://github.com/vapor/postgres-nio.git
+- https://github.com/vapor/vapor.git

--- a/_data/server-workgroup/incubating.yml
+++ b/_data/server-workgroup/incubating.yml
@@ -1,0 +1,10 @@
+- https://github.com/apple/swift-cassandra-client.git
+- https://github.com/apple/swift-distributed-tracing.git
+- https://github.com/apple/swift-service-context.git
+- https://github.com/GraphQLSwift/Graphiti.git
+- https://github.com/GraphQLSwift/GraphQL.git
+- https://github.com/mongodb/mongo-swift-driver.git
+- https://github.com/orlandos-nl/MongoKitten.git
+- https://github.com/soto-project/soto.git
+- https://github.com/swift-server/swift-backtrace.git
+- https://github.com/swift-server/swift-service-lifecycle.git

--- a/_data/server-workgroup/sandbox.yml
+++ b/_data/server-workgroup/sandbox.yml
@@ -1,0 +1,11 @@
+- https://github.com/apple/swift-distributed-actors.git
+- https://github.com/apple/swift-openapi-generator.git
+- https://github.com/discordbm/discordbm.git
+- https://github.com/hummingbird-project/hummingbird.git
+- https://github.com/lovetodream/oracle-nio.git
+- https://github.com/mattpolzin/OpenAPIKit.git
+- https://github.com/swift-server-community/mqtt-nio.git
+- https://github.com/swift-server/RediStack.git
+- https://github.com/swift-server/swift-aws-lambda-runtime.git
+- https://github.com/swift-server/swift-prometheus.git
+- https://github.com/vapor/sqlite-nio.git


### PR DESCRIPTION
### Motivation:

This adds the data files to manage packages following the [SSWG incubation process](https://www.swift.org/sswg/incubation-process.html). They will also be the basis for custom package collections on the Swift Package Index.

### Modifications:

Adds three files with package URLs.

To do, as discussed with @0xTim :

- [ ] make sure the YML files are configured to be processed to JSON files at the appropriate URL, probably `https://github.com/swiftlang/swift-org-website/blob/main/api/v1/install/{graduated|incubating|sandbox}.json` - perhaps they should have an `sswg-prefix`?
- [ ] update the files to reflect the latest review