### PR TITLE
Updated Community Showcase packages for November

### DIFF
--- a/_data/packages/packages.yml
+++ b/_data/packages/packages.yml
@@ -9,61 +9,77 @@ categories:
       organised via [this thread in the Swift Forums](https://forums.swift.org/t/68168)
       and curated by the [Swift Website Workgroup](https://www.swift.org/website-workgroup/).
     packages:
-      - name: Chip8iEmulationCore
-        description: Emulates the CHIP-8 system from the 1970s, running programs, processing
-          operations, handling input, and subscribing to screen output and sound updates
-          for frontend applications.
-        owner: Danijel Stracenski
+      - name: swift-crypto
+        description: Swift Crypto is an open-source implementation of a substantial portion
+          of the API of Apple CryptoKit suitable for use on Linux platforms. It enables
+          cross-platform or server applications with the advantages of CryptoKit.
+        owner: Apple
         swift_compatibility: 5.9+
         platform_compatibility:
           - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+          - Linux
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
+        license: Apache 2.0
+        url: https://swiftpackageindex.com/apple/swift-crypto
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/93){:target='_blank'}.
+      - name: Recap
+        description: Displays "What's New" screens for apps, supporting flexible release
+          history, customization, and semantic versioning. Utilizes Markdown for release
+          notes and offers modifiers for design customization.
+        owner: Joe Fabisevich
+        swift_compatibility: 6.0+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS)
         license: MIT
-        url: https://swiftpackageindex.com/danijelLoc/Chip8iEmulationCore
-        note: Discussed on [Episode 49 of Swift Package Indexing](https://share.transistor.fm/s/c3ea4e1a){:target='_blank'}.
-      - name: elementary
-        description: HTML rendering library inspired by SwiftUI for web development. Utilizes
-          Swift's generics for type-safe, efficient HTML streaming without dependencies.
-          Supports async rendering and environment values.
-        owner: Simon Leeb
+        url: https://swiftpackageindex.com/mergesort/Recap
+        note: Discussed on [Episode 50 of Swift Package Indexing](https://share.transistor.fm/s/333d2750){:target='_blank'}.
+      - name: package-frostflake
+        description: High-performance unique ID generator for distributed systems, inspired
+          by Snowflake. Each identifier is half the size of a UUID and is suitable for
+          use as a database key.
+        owner: Ordo One
+        swift_compatibility: 5.8+
+        platform_compatibility:
+          - Apple
+          - Linux
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
+        license: Apache 2.0
+        url: https://swiftpackageindex.com/ordo-one/package-frostflake
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/89){:target='_blank'}.
+      - name: swift-async-operations
+        description: Enhances Swift concurrency by providing async operations like `asyncMap`,
+          enabling sequential or parallel execution of closures on sequences while preserving
+          order using Ordered Task Group.
+        owner: matsuji
         swift_compatibility: 5.10+
         platform_compatibility:
           - Apple
           - Linux
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
           Linux
-        license: Apache 2.0
-        url: https://swiftpackageindex.com/sliemeobn/elementary
-        note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/82){:target='_blank'}.
-      - name: swift-openapi-generator
-        description: Generate Swift client and server code from an OpenAPI document. Includes
-          multiple repositories for extensibility and supports various transports.
-        owner: Apple
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (macOS) and Linux
-        license: Apache 2.0
-        url: https://swiftpackageindex.com/apple/swift-openapi-generator
-        note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/84){:target='_blank'}.
-      - name: swift-export
-        description: Command-line tool for generating signed and notarized macOS installer
-          packages from Swift projects, with support for configuration files, sandboxing,
-          entitlements, and additional payloads.
-        owner: Frank Lefebvre
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (macOS) and Linux
         license: MIT
-        url: https://swiftpackageindex.com/franklefebvre/swift-export
-        note: Linked to in [Issue 679 of iOS Dev Weekly](https://iosdevweekly.com/issues/679#DXo4Uf9){:target='_blank'}.
-      - name: SpectreKit
-        description: Facilitates the creation of aesthetically pleasing terminal applications
-          in Swift, inspired by Spectre.Console and Python's Rich, currently under development.
-        owner: Patrik Svensson
+        url: https://swiftpackageindex.com/mtj0928/swift-async-operations
+        note: Discussed on [Episode 50 of Swift Package Indexing](https://share.transistor.fm/s/333d2750){:target='_blank'}.
+      - name: TinyStorage
+        description: TinyStorage replaces `UserDefaults` with a lightweight, reliable
+          storage solution supporting Swift `Codable` types. It's ideal for storing small,
+          non-sensitive data but is not secure for sensitive information.
+        owner: Christian Selig
+        swift_compatibility: 6.0+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+        license: MIT
+        url: https://swiftpackageindex.com/christianselig/TinyStorage
+        note: Discussed on [Episode 50 of Swift Package Indexing](https://share.transistor.fm/s/333d2750){:target='_blank'}.
+      - name: Graphs
+        description: Provides a composable, extensible foundation for working with abstract
+          graphs, supporting various types, algorithms, and traversal strategies. Ideal
+          for constructing, analyzing, and optimizing complex graph structures.
+        owner: Laszlo Teveli
         swift_compatibility: 5.9+
         platform_compatibility:
           - Apple
@@ -71,19 +87,8 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
           Linux
         license: MIT
-        url: https://swiftpackageindex.com/patriksvensson/spectre-kit
-        note: Discussed on [Episode 49 of Swift Package Indexing](https://share.transistor.fm/s/c3ea4e1a){:target='_blank'}.
-      - name: DeclarativeTextKit
-        description: Swift DSL for modifying text buffers declaratively, supporting undo
-          operations and changes across multiple buffers without UI rendering.
-        owner: Clean Cocoa
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (macOS)
-        license: MIT
-        url: https://swiftpackageindex.com/CleanCocoa/DeclarativeTextKit
-        note: Discussed on [Episode 49 of Swift Package Indexing](https://share.transistor.fm/s/53ee9157){:target='_blank'}.
+        url: https://swiftpackageindex.com/tevelee/swift-graphs
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/91){:target='_blank'}.
   - name: Packages with Macros
     slug: macros
     brief: New in Swift 5.9, Swift packages can include macro targets. Browse a selection

--- a/_data/packages/showcase-history.yml
+++ b/_data/packages/showcase-history.yml
@@ -1,6 +1,84 @@
 years:
   - year: 2024
     months:
+      - month: October
+        slug: october
+        packages:
+          - name: Chip8iEmulationCore
+            description: Emulates the CHIP-8 system from the 1970s, running programs, processing
+              operations, handling input, and subscribing to screen output and sound updates
+              for frontend applications.
+            owner: Danijel Stracenski
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/danijelLoc/Chip8iEmulationCore
+            note: Discussed on [Episode 49 of Swift Package Indexing](https://share.transistor.fm/s/c3ea4e1a){:target='_blank'}.
+          - name: elementary
+            description: HTML rendering library inspired by SwiftUI for web development.
+              Utilizes Swift's generics for type-safe, efficient HTML streaming without
+              dependencies. Supports async rendering and environment values.
+            owner: Simon Leeb
+            swift_compatibility: 5.10+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/sliemeobn/elementary
+            note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/82){:target='_blank'}.
+          - name: swift-openapi-generator
+            description: Generate Swift client and server code from an OpenAPI document.
+              Includes multiple repositories for extensibility and supports various transports.
+            owner: Apple
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (macOS) and Linux
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/apple/swift-openapi-generator
+            note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/84){:target='_blank'}.
+          - name: swift-export
+            description: Command-line tool for generating signed and notarized macOS installer
+              packages from Swift projects, with support for configuration files, sandboxing,
+              entitlements, and additional payloads.
+            owner: Frank Lefebvre
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (macOS) and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/franklefebvre/swift-export
+            note: Linked to in [Issue 679 of iOS Dev Weekly](https://iosdevweekly.com/issues/679#DXo4Uf9){:target='_blank'}.
+          - name: SpectreKit
+            description: Facilitates the creation of aesthetically pleasing terminal applications
+              in Swift, inspired by Spectre.Console and Python's Rich, currently under development.
+            owner: Patrik Svensson
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/patriksvensson/spectre-kit
+            note: Discussed on [Episode 49 of Swift Package Indexing](https://share.transistor.fm/s/c3ea4e1a){:target='_blank'}.
+          - name: DeclarativeTextKit
+            description: Swift DSL for modifying text buffers declaratively, supporting
+              undo operations and changes across multiple buffers without UI rendering.
+            owner: Clean Cocoa
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (macOS)
+            license: MIT
+            url: https://swiftpackageindex.com/CleanCocoa/DeclarativeTextKit
+            note: Discussed on [Episode 49 of Swift Package Indexing](https://share.transistor.fm/s/53ee9157){:target='_blank'}.
       - month: September
         slug: september
         packages:


### PR DESCRIPTION
This update contains the [Community Showcase packages](https://www.swift.org/packages/showcase.html) for November.

Packages in the Community Showcase are nominated by the community in [this thread on the Swift forums](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168) and voted on by the [SWWG](https://www.swift.org/website-workgroup/).

![Screenshot 2024-11-18 at 16 17 14@2x](https://github.com/user-attachments/assets/d4ecff9b-56ee-48ce-a1c1-e57a5529fb57)

