### PR TITLE
Updated Community Showcase packages for December

### DIFF
--- a/_data/packages/packages.yml
+++ b/_data/packages/packages.yml
@@ -9,51 +9,50 @@ categories:
       organised via [this thread in the Swift Forums](https://forums.swift.org/t/68168)
       and curated by the [Swift Website Workgroup](https://www.swift.org/website-workgroup/).
     packages:
-      - name: swift-crypto
-        description: Swift Crypto is an open-source implementation of a substantial portion
-          of the API of Apple CryptoKit suitable for use on Linux platforms. It enables
-          cross-platform or server applications with the advantages of CryptoKit.
-        owner: Apple
+      - name: GestureButton
+        description: GestureButton enables multiple gesture-specific actions using a single
+          SwiftUI button. Customize actions for gestures like tap, long press, and drag,
+          with flexible delays and timeouts.
+        owner: Daniel Saidi
+        swift_compatibility: 6.0+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+        license: MIT
+        url: https://swiftpackageindex.com/danielsaidi/GestureButton
+        note: Discussed on [Episode 51 of Swift Package Indexing](https://share.transistor.fm/s/257bd1fa){:target='_blank'}.
+      - name: JSONPatch
+        description: "Swift \u03BC-framework for creating RFC6902-compliant JSON patch
+          objects, supporting operations like add, remove, replace, move, copy, and test
+          using keypaths."
+        owner: Peter Ringset
+        swift_compatibility: 5.10+
+        platform_compatibility:
+          - Apple
+          - Linux
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS) and Linux
+        license: MIT
+        url: https://swiftpackageindex.com/peterringset/JSONPatch
+        note: Discussed on [Episode 51 of Swift Package Indexing](https://share.transistor.fm/s/257bd1fa){:target='_blank'}.
+      - name: xctest-dynamic-overlay
+        description: Swift Issue Reporting enables reporting issues in code as runtime
+          warnings, breakpoints, or assertions, and converts them into test failures,
+          aiding debugging and ensuring test coverage.
+        owner: Point-Free
         swift_compatibility: 5.9+
         platform_compatibility:
           - Apple
           - Linux
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
           Linux
-        license: Apache 2.0
-        url: https://swiftpackageindex.com/apple/swift-crypto
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/93){:target='_blank'}.
-      - name: Recap
-        description: Displays "What's New" screens for apps, supporting flexible release
-          history, customization, and semantic versioning. Utilizes Markdown for release
-          notes and offers modifiers for design customization.
-        owner: Joe Fabisevich
-        swift_compatibility: 6.0+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS)
         license: MIT
-        url: https://swiftpackageindex.com/mergesort/Recap
-        note: Discussed on [Episode 50 of Swift Package Indexing](https://share.transistor.fm/s/333d2750){:target='_blank'}.
-      - name: package-frostflake
-        description: High-performance unique ID generator for distributed systems, inspired
-          by Snowflake. Each identifier is half the size of a UUID and is suitable for
-          use as a database key.
-        owner: Ordo One
-        swift_compatibility: 5.8+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: Apache 2.0
-        url: https://swiftpackageindex.com/ordo-one/package-frostflake
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/89){:target='_blank'}.
-      - name: swift-async-operations
-        description: Enhances Swift concurrency by providing async operations like `asyncMap`,
-          enabling sequential or parallel execution of closures on sequences while preserving
-          order using Ordered Task Group.
-        owner: matsuji
+        url: https://swiftpackageindex.com/pointfreeco/swift-issue-reporting
+        note: Linked to in [Issue 671 of iOS Dev Weekly](https://iosdevweekly.com/issues/671#gpHvv6S){:target='_blank'}.
+      - name: BijectiveDictionary
+        description: Swift Bijective Dictionary provides efficient bidirectional key-value
+          access with O(1) complexity, suitable for scenarios requiring fast reverse lookups.
+          It mirrors standard dictionary functionality with additional memory usage.
+        owner: Jacob Gelman
         swift_compatibility: 5.10+
         platform_compatibility:
           - Apple
@@ -61,34 +60,33 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
           Linux
         license: MIT
-        url: https://swiftpackageindex.com/mtj0928/swift-async-operations
-        note: Discussed on [Episode 50 of Swift Package Indexing](https://share.transistor.fm/s/333d2750){:target='_blank'}.
-      - name: TinyStorage
-        description: TinyStorage replaces `UserDefaults` with a lightweight, reliable
-          storage solution supporting Swift `Codable` types. It's ideal for storing small,
-          non-sensitive data but is not secure for sensitive information.
-        owner: Christian Selig
+        url: https://swiftpackageindex.com/ladvoc/BijectiveDictionary
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/90){:target='_blank'}.
+      - name: SwiftClaude
+        description: SwiftClaude enables communication with Anthropic's Claude API, supporting
+          conversations, tool use, vision integration, and prompt caching in Swift applications.
+          It offers async and observable APIs for handling messages.
+        owner: George Lyon
         swift_compatibility: 6.0+
         platform_compatibility:
           - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+          - Linux
+        platform_compatibility_tooltip: Apple (macOS) and Linux
         license: MIT
-        url: https://swiftpackageindex.com/christianselig/TinyStorage
-        note: Discussed on [Episode 50 of Swift Package Indexing](https://share.transistor.fm/s/333d2750){:target='_blank'}.
-      - name: Graphs
-        description: Provides a composable, extensible foundation for working with abstract
-          graphs, supporting various types, algorithms, and traversal strategies. Ideal
-          for constructing, analyzing, and optimizing complex graph structures.
-        owner: Laszlo Teveli
+        url: https://swiftpackageindex.com/GeorgeLyon/SwiftClaude
+        note: Discussed on [Episode 51 of Swift Package Indexing](https://share.transistor.fm/s/257bd1fa){:target='_blank'}.
+      - name: SwiftTranslate
+        description: Facilitates app localization by translating string catalogs using
+          OpenAI's GPT models or Google Cloud Translate. Supports multiple languages,
+          complex string variations, and offers a CLI tool and Swift Package Plugin.
+        owner: Hidden Spectrum
         swift_compatibility: 5.9+
         platform_compatibility:
           - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
+        platform_compatibility_tooltip: Apple (macOS, visionOS)
         license: MIT
-        url: https://swiftpackageindex.com/tevelee/swift-graphs
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/91){:target='_blank'}.
+        url: https://swiftpackageindex.com/hidden-spectrum/swift-translate
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/76){:target='_blank'}.
   - name: Packages with Macros
     slug: macros
     brief: New in Swift 5.9, Swift packages can include macro targets. Browse a selection

--- a/_data/packages/showcase-history.yml
+++ b/_data/packages/showcase-history.yml
@@ -1,6 +1,89 @@
 years:
   - year: 2024
     months:
+      - month: November
+        slug: november
+        packages:
+          - name: swift-crypto
+            description: Swift Crypto is an open-source implementation of a substantial
+              portion of the API of Apple CryptoKit suitable for use on Linux platforms.
+              It enables cross-platform or server applications with the advantages of CryptoKit.
+            owner: Apple
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/apple/swift-crypto
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/93){:target='_blank'}.
+          - name: Recap
+            description: Displays "What's New" screens for apps, supporting flexible release
+              history, customization, and semantic versioning. Utilizes Markdown for release
+              notes and offers modifiers for design customization.
+            owner: Joe Fabisevich
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS)
+            license: MIT
+            url: https://swiftpackageindex.com/mergesort/Recap
+            note: Discussed on [Episode 50 of Swift Package Indexing](https://share.transistor.fm/s/333d2750){:target='_blank'}.
+          - name: package-frostflake
+            description: High-performance unique ID generator for distributed systems, inspired
+              by Snowflake. Each identifier is half the size of a UUID and is suitable for
+              use as a database key.
+            owner: Ordo One
+            swift_compatibility: 5.8+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/ordo-one/package-frostflake
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/89){:target='_blank'}.
+          - name: swift-async-operations
+            description: Enhances Swift concurrency by providing async operations like `asyncMap`,
+              enabling sequential or parallel execution of closures on sequences while preserving
+              order using Ordered Task Group.
+            owner: matsuji
+            swift_compatibility: 5.10+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/mtj0928/swift-async-operations
+            note: Discussed on [Episode 50 of Swift Package Indexing](https://share.transistor.fm/s/333d2750){:target='_blank'}.
+          - name: TinyStorage
+            description: TinyStorage replaces `UserDefaults` with a lightweight, reliable
+              storage solution supporting Swift `Codable` types. It's ideal for storing
+              small, non-sensitive data but is not secure for sensitive information.
+            owner: Christian Selig
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/christianselig/TinyStorage
+            note: Discussed on [Episode 50 of Swift Package Indexing](https://share.transistor.fm/s/333d2750){:target='_blank'}.
+          - name: Graphs
+            description: Provides a composable, extensible foundation for working with abstract
+              graphs, supporting various types, algorithms, and traversal strategies. Ideal
+              for constructing, analyzing, and optimizing complex graph structures.
+            owner: Laszlo Teveli
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/tevelee/swift-graphs
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/91){:target='_blank'}.
       - month: October
         slug: october
         packages:


### PR DESCRIPTION
Merge after #858.

This update contains the [Community Showcase packages](https://www.swift.org/packages/showcase.html) for December.

Packages in the Community Showcase are nominated by the community in [this thread on the Swift forums](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168) and voted on by the [SWWG](https://www.swift.org/website-workgroup/).

![Screenshot 2024-12-10 at 13 33 34@2x](https://github.com/user-attachments/assets/8d13f9b9-d695-42df-9ee0-714c8f00be2b)
