### PR TITLE
Swift 6.0.3 Release

### DIFF
--- a/_data/builds/swift_releases.yml
+++ b/_data/builds/swift_releases.yml
@@ -1936,3 +1936,64 @@
       archs:
         - x86_64
         - arm64
+- name: "6.0.3"
+  tag: swift-6.0.3-RELEASE
+  xcode: Xcode 16.2
+  xcode_release: true
+  date: 2024-12-11
+  platforms:
+    - name: Ubuntu 20.04
+      platform: Linux
+      docker: 6.0.3-focal
+      archs:
+        - x86_64
+        - aarch64
+    - name: Ubuntu 22.04
+      platform: Linux
+      docker: 6.0.3-jammy
+      archs:
+        - x86_64
+        - aarch64
+    - name: Ubuntu 24.04
+      platform: Linux
+      docker: 6.0.3-noble
+      archs:
+        - x86_64
+        - aarch64
+    - name: Debian 12
+      platform: Linux
+      docker: 6.0.3-bookworm
+      archs:
+        - x86_64
+        - aarch64
+    - name: Fedora 39
+      platform: Linux
+      docker: 6.0.3-fedora39
+      archs:
+        - x86_64
+        - aarch64
+    - name: Amazon Linux 2
+      platform: Linux
+      docker: 6.0.3-amazonlinux2
+      archs:
+        - x86_64
+        - aarch64
+    - name: Red Hat Universal Base Image 9
+      platform: Linux
+      docker: 6.0.3-rhel-ubi9
+      dir: ubi9
+      archs:
+        - x86_64
+        - aarch64
+    - name: Windows 10
+      platform: Windows
+      docker: 6.0.3-windowsservercore-ltsc2022
+      archs:
+        - x86_64
+        - arm64
+    - name: Static SDK
+      platform: static-sdk
+      checksum: 67f765e0030e661a7450f7e4877cfe008db4f57f177d5a08a6e26fd661cdd0bd
+      archs:
+        - x86_64
+        - arm64

--- a/_includes/install/_old-release.html
+++ b/_includes/install/_old-release.html
@@ -44,6 +44,23 @@
         Unavailable
     {% endif %}
     </td>
+    {% if platform.platform != "Windows" %}
+    <td class="docker-tag">
+        {% assign release_info = site.data.builds.swift_releases| where: 'tag', include.release.tag | first %}
+        {% assign static_sdk = release_info.platforms | where: 'name', 'Static SDK'| first %}
+    {% if static_sdk %}
+        {% assign tag_downcase = include.release.tag | downcase %}
+        <button onclick="copyToClipboard('swift sdk install https://download.swift.org/{{ tag_downcase }}/static-sdk/{{ include.release.tag }}/{{ include.release.tag }}_static-linux-0.0.1.artifactbundle.tar.gz --checksum {{ static_sdk.checksum }}')">Copy install command</button>
+    <script>
+        function copyToClipboard(text) {
+          navigator.clipboard.writeText(text)
+        }
+    </script>
+    {% else %}
+        Unavailable
+    {% endif %}
+    </td>
+    {% endif %}
 </tr>
 {% endif %}
 {% endfor %}

--- a/_includes/install/_older-releases.md
+++ b/_includes/install/_older-releases.md
@@ -5,6 +5,9 @@
             <th class="download">Date</th>
             <th class="download">Toolchain</th>
             <th class="download">Docker</th>
+            {% if include.platform != "Windows 10" %}
+            <th class="download">Static SDK</th>
+            {% endif %}
         </tr>
     </thead>
     <tbody>

--- a/_includes/install/_static_sdk_release.md
+++ b/_includes/install/_static_sdk_release.md
@@ -1,14 +1,18 @@
+{% assign tag = site.data.builds.swift_releases.last.tag %}
+{% assign tag_downcase = site.data.builds.swift_releases.last.tag | downcase %}
+{% assign platform = site.data.builds.swift_releases.last.platforms | where: 'name', 'Static SDK'| first %}
+
 <li class="grid-level-1 featured">
   <h3>Static Linux SDK </h3>
   <p class="description">
     Static Linux SDK - Cross compile to Linux
     <ul>
-      <li><a href="https://download.swift.org/swift-6.0.2-release/static-sdk/swift-6.0.2-RELEASE/swift-6.0.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz.sig">Signature (PGP)</a>
+      <li><a href="https://download.swift.org/{{ tag_downcase }}/static-sdk/{{ tag }}/{{ tag }}_static-linux-0.0.1.artifactbundle.tar.gz.sig">Signature (PGP)</a>
       </li>
       <li>
-        Checksum: <code>aa5515476a403797223fc2aad4ca0c3bf83995d5427fb297cab1d93c68cee075</code></li>
+        Checksum: <code>{{ platform.checksum }}</code></li>
     </ul>
   </p>
-  <a href="https://download.swift.org/swift-6.0.2-release/static-sdk/swift-6.0.2-RELEASE/swift-6.0.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz" class="cta-secondary">Download Linux Static SDK</a>
+  <a href="https://download.swift.org/{{ tag_downcase }}/static-sdk/{{ tag }}/{{ tag }}_static-linux-0.0.1.artifactbundle.tar.gz" class="cta-secondary">Download Linux Static SDK</a>
   <a href="/documentation/articles/static-linux-getting-started.html" class="cta-secondary">Instructions (Static Linux SDK)</a>
 </li>

--- a/install/macos/_old-release.html
+++ b/install/macos/_old-release.html
@@ -15,5 +15,20 @@
           <a href="https://download.swift.org/{{ include.release.tag | downcase }}/xcode/{{ include.release.tag }}/{{ include.release.tag }}-osx-symbols.pkg" title="Debugging Symbols">Debugging Symbols</a>
         </span>
     </td>
+    <td class="release">
+        {% assign release_info = site.data.builds.swift_releases | where: 'tag', include.release.tag | first %}
+        {% assign static_sdk = release_info.platforms | where: 'name', 'Static SDK'| first %}
+    {% if static_sdk %}
+        {% assign tag_downcase = include.release.tag | downcase %}
+        <button onclick="copyToClipboard('swift sdk install https://download.swift.org/{{ tag_downcase }}/static-sdk/{{ include.release.tag }}/{{ include.release.tag }}_static-linux-0.0.1.artifactbundle.tar.gz --checksum {{ static_sdk.checksum }}')">Copy install command</button>
+    <script>
+        function copyToClipboard(text) {
+          navigator.clipboard.writeText(text)
+        }
+    </script>
+    {% else %}
+        Unavailable
+    {% endif %}
+    </td>
 </tr>
           

--- a/install/macos/_older-releases.md
+++ b/install/macos/_older-releases.md
@@ -5,6 +5,7 @@
             <th class="download">Date</th>
             <th class="download">Toolchain</th>
             <th class="download">Debugging Symbols</th>
+            <th class="download">Static SDK</th>
         </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
<img width="851" alt="Screenshot 2024-12-11 at 11 14 14 PM" src="https://github.com/user-attachments/assets/ea879831-af71-457c-81a1-b45c4c8f93d0" />

Older release view now contains a link to copy the static sdk command:
<img width="839" alt="Screenshot 2024-12-11 at 11 14 23 PM" src="https://github.com/user-attachments/assets/aeb4352e-6124-4a01-9420-b961df32cc88" />
