### PR TITLE
Append `.git` for SwiftASN1's URL  at projects.yml

### DIFF
--- a/_data/server-workgroup/projects.yml
+++ b/_data/server-workgroup/projects.yml
@@ -220,4 +220,4 @@
   maturity: Sandbox
   pitched: 2024-08-20
   accepted: 2025-01-06
-  url: https://github.com/apple/swift-asn1
+  url: https://github.com/apple/swift-asn1.git


### PR DESCRIPTION
As refer the PR https://github.com/swiftlang/swift-org-website/pull/868 of @0xTim . I have a minor enhance that appends `.git` for SwiftASN1's URL that will be consistent with other URLs.

### Motivation:

Appends `.git` for SwiftASN1's URL that will be consistent with other URLs.

### Modifications:

+ _data/server-workgroup/projects.yml

### Result:

That will be consistent with other URLs in `projects.yml`
