### PR TITLE
Update reference to docs/SIL.rst to docs/SIL/SIL.md

### DIFF
--- a/documentation/swift-compiler/_compiler-architecture.md
+++ b/documentation/swift-compiler/_compiler-architecture.md
@@ -37,7 +37,7 @@ high-level description of the major components of the Swift compiler:
   [lib/SILGen](https://github.com/swiftlang/swift/tree/main/lib/SILGen))
   lowers the type-checked AST into so-called "raw" SIL.  The design of
   SIL is described in
-  [docs/SIL.rst](https://github.com/swiftlang/swift/blob/main/docs/SIL.rst).
+  [docs/SIL/SIL.md](https://github.com/swiftlang/swift/blob/main/docs/SIL/SIL.md).
 
 * **SIL guaranteed transformations**: The SIL guaranteed
     transformations (implemented in


### PR DESCRIPTION
Related to https://github.com/swiftlang/swift/pull/78215 & https://github.com/swiftlang/swift/pull/77714

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

Update reference to `docs/SIL.rst` to new `docs/SIL/SIL.md`

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

* Fixing a broken documentation link

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->
* Modified the `Compiler Architecture` page to update link to SIL documentation in the Swift repo

### Result:

<!-- _[After your change, what will change.]_ -->
* A link on the page that will direct the user to the correct file.
