### PR TITLE
Updated Community Showcase packages for January

### DIFF
--- a/_data/packages/packages.yml
+++ b/_data/packages/packages.yml
@@ -9,84 +9,83 @@ categories:
       organised via [this thread in the Swift Forums](https://forums.swift.org/t/68168)
       and curated by the [Swift Website Workgroup](https://www.swift.org/website-workgroup/).
     packages:
-      - name: GestureButton
-        description: GestureButton enables multiple gesture-specific actions using a single
-          SwiftUI button. Customize actions for gestures like tap, long press, and drag,
-          with flexible delays and timeouts.
-        owner: Daniel Saidi
-        swift_compatibility: 6.0+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-        license: MIT
-        url: https://swiftpackageindex.com/danielsaidi/GestureButton
-        note: Discussed on [Episode 51 of Swift Package Indexing](https://share.transistor.fm/s/257bd1fa){:target='_blank'}.
-      - name: JSONPatch
-        description: "Swift \u03BC-framework for creating RFC6902-compliant JSON patch
-          objects, supporting operations like add, remove, replace, move, copy, and test
-          using keypaths."
-        owner: Peter Ringset
-        swift_compatibility: 5.10+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS) and Linux
-        license: MIT
-        url: https://swiftpackageindex.com/peterringset/JSONPatch
-        note: Discussed on [Episode 51 of Swift Package Indexing](https://share.transistor.fm/s/257bd1fa){:target='_blank'}.
-      - name: xctest-dynamic-overlay
-        description: Swift Issue Reporting enables reporting issues in code as runtime
-          warnings, breakpoints, or assertions, and converts them into test failures,
-          aiding debugging and ensuring test coverage.
-        owner: Point-Free
+      - name: Queue
+        description: Exposes `AsyncQueue` for managing asynchronous tasks in Swift, ensuring
+          ordered execution without explicit dependencies, and handling errors through
+          an `errorSequence` property.
+        owner: Matt Massicotte
         swift_compatibility: 5.9+
         platform_compatibility:
           - Apple
           - Linux
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
           Linux
-        license: MIT
-        url: https://swiftpackageindex.com/pointfreeco/swift-issue-reporting
-        note: Linked to in [Issue 671 of iOS Dev Weekly](https://iosdevweekly.com/issues/671#gpHvv6S){:target='_blank'}.
-      - name: BijectiveDictionary
-        description: Swift Bijective Dictionary provides efficient bidirectional key-value
-          access with O(1) complexity, suitable for scenarios requiring fast reverse lookups.
-          It mirrors standard dictionary functionality with additional memory usage.
-        owner: Jacob Gelman
-        swift_compatibility: 5.10+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: MIT
-        url: https://swiftpackageindex.com/ladvoc/BijectiveDictionary
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/90){:target='_blank'}.
-      - name: SwiftClaude
-        description: SwiftClaude enables communication with Anthropic's Claude API, supporting
-          conversations, tool use, vision integration, and prompt caching in Swift applications.
-          It offers async and observable APIs for handling messages.
-        owner: George Lyon
-        swift_compatibility: 6.0+
+        license: BSD 3-Clause
+        url: https://swiftpackageindex.com/mattmassicotte/Queue
+        note: Discussed on [Episode 52 of Swift Package Indexing](https://share.transistor.fm/s/687d1170){:target='_blank'}.
+      - name: SwiftCommand
+        description: Wrapper for `Foundation.Process`, inspired by Rust's `std::process::Command`.
+          Facilitates command line program execution and I/O handling using synchronous
+          or `async`/`await` APIs.
+        owner: Josef Zoller
+        swift_compatibility: 5.8+
         platform_compatibility:
           - Apple
           - Linux
         platform_compatibility_tooltip: Apple (macOS) and Linux
         license: MIT
-        url: https://swiftpackageindex.com/GeorgeLyon/SwiftClaude
-        note: Discussed on [Episode 51 of Swift Package Indexing](https://share.transistor.fm/s/257bd1fa){:target='_blank'}.
-      - name: SwiftTranslate
-        description: Facilitates app localization by translating string catalogs using
-          OpenAI's GPT models or Google Cloud Translate. Supports multiple languages,
-          complex string variations, and offers a CLI tool and Swift Package Plugin.
-        owner: Hidden Spectrum
+        url: https://swiftpackageindex.com/Zollerboy1/SwiftCommand
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/110){:target='_blank'}.
+      - name: SoulverCore
+        description: SoulverCore provides a natural language math engine for calculations,
+          unit conversions, currency rates, and custom functions, with high performance
+          and extensibility.
+        owner: Soulver
+        swift_compatibility: 5.8+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, macOS)
+        license: Unknown license
+        url: https://swiftpackageindex.com/soulverteam/SoulverCore
+        note: Discussed on [Episode 52 of Swift Package Indexing](https://share.transistor.fm/s/687d1170){:target='_blank'}.
+      - name: swift-mustache
+        description: Swift-Mustache enables rendering of Mustache templates, a logic-less
+          templating language. It supports standard Mustache tags, template inheritance,
+          and custom features like transforms, excluding Lambda support.
+        owner: Hummingbird
+        swift_compatibility: 5.8+
+        platform_compatibility:
+          - Apple
+          - Linux
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
+        license: Apache 2.0
+        url: https://swiftpackageindex.com/hummingbird-project/swift-mustache
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/107){:target='_blank'}.
+      - name: ColorToolbox
+        description: ColorToolbox provides Swift color utilities for UIKit, AppKit, and
+          SwiftUI. It includes features such as converting from and to hex strings, calculating
+          relative luminance and WCAG contrast ratio, and lightening/darkening colors.
+        owner: Ramon Torres
         swift_compatibility: 5.9+
         platform_compatibility:
           - Apple
-        platform_compatibility_tooltip: Apple (macOS, visionOS)
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
         license: MIT
-        url: https://swiftpackageindex.com/hidden-spectrum/swift-translate
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/76){:target='_blank'}.
+        url: https://swiftpackageindex.com/raymondjavaxx/ColorToolbox
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/114){:target='_blank'}.
+      - name: Orb
+        description: SwiftUI component for creating customizable animated orbs with effects
+          like glowing, particles, and dynamic animations, inspired by Siri animations.
+          Ideal for interactive and visually appealing UI designs.
+        owner: Siddhant Mehta
+        swift_compatibility: 6.0+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, visionOS, tvOS)
+        license: MIT
+        url: https://swiftpackageindex.com/metasidd/Orb
+        note: Discussed on [Episode 52 of Swift Package Indexing](https://share.transistor.fm/s/687d1170){:target='_blank'}.
   - name: Packages with Macros
     slug: macros
     brief: New in Swift 5.9, Swift packages can include macro targets. Browse a selection

--- a/_data/packages/showcase-history.yml
+++ b/_data/packages/showcase-history.yml
@@ -1,6 +1,88 @@
 years:
   - year: 2024
     months:
+      - month: December
+        slug: december
+        packages:
+          - name: GestureButton
+            description: GestureButton enables multiple gesture-specific actions using a
+              single SwiftUI button. Customize actions for gestures like tap, long press,
+              and drag, with flexible delays and timeouts.
+            owner: Daniel Saidi
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/danielsaidi/GestureButton
+            note: Discussed on [Episode 51 of Swift Package Indexing](https://share.transistor.fm/s/257bd1fa){:target='_blank'}.
+          - name: JSONPatch
+            description: "Swift \u03BC-framework for creating RFC6902-compliant JSON patch
+              objects, supporting operations like add, remove, replace, move, copy, and
+              test using keypaths."
+            owner: Peter Ringset
+            swift_compatibility: 5.10+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS) and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/peterringset/JSONPatch
+            note: Discussed on [Episode 51 of Swift Package Indexing](https://share.transistor.fm/s/257bd1fa){:target='_blank'}.
+          - name: xctest-dynamic-overlay
+            description: Swift Issue Reporting enables reporting issues in code as runtime
+              warnings, breakpoints, or assertions, and converts them into test failures,
+              aiding debugging and ensuring test coverage.
+            owner: Point-Free
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/pointfreeco/swift-issue-reporting
+            note: Linked to in [Issue 671 of iOS Dev Weekly](https://iosdevweekly.com/issues/671#gpHvv6S){:target='_blank'}.
+          - name: BijectiveDictionary
+            description: Swift Bijective Dictionary provides efficient bidirectional key-value
+              access with O(1) complexity, suitable for scenarios requiring fast reverse
+              lookups. It mirrors standard dictionary functionality with additional memory
+              usage.
+            owner: Jacob Gelman
+            swift_compatibility: 5.10+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/ladvoc/BijectiveDictionary
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/90){:target='_blank'}.
+          - name: SwiftClaude
+            description: SwiftClaude enables communication with Anthropic's Claude API,
+              supporting conversations, tool use, vision integration, and prompt caching
+              in Swift applications. It offers async and observable APIs for handling messages.
+            owner: George Lyon
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (macOS) and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/GeorgeLyon/SwiftClaude
+            note: Discussed on [Episode 51 of Swift Package Indexing](https://share.transistor.fm/s/257bd1fa){:target='_blank'}.
+          - name: SwiftTranslate
+            description: Facilitates app localization by translating string catalogs using
+              OpenAI's GPT models or Google Cloud Translate. Supports multiple languages,
+              complex string variations, and offers a CLI tool and Swift Package Plugin.
+            owner: Hidden Spectrum
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (macOS, visionOS)
+            license: MIT
+            url: https://swiftpackageindex.com/hidden-spectrum/swift-translate
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/76){:target='_blank'}.
       - month: November
         slug: november
         packages:


### PR DESCRIPTION
This update contains the [Community Showcase packages](https://www.swift.org/packages/showcase.html) for January.

Packages in the Community Showcase are nominated by the community in [this thread on the Swift forums](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168) and voted on by the [SWWG](https://www.swift.org/website-workgroup/).

![Screenshot 2025-01-15 at 13 12 46@2x](https://github.com/user-attachments/assets/3deefd72-b324-4453-8719-74045393c8aa)
