### PR TITLE
Remove Paris from WWG

### DIFF
--- a/_data/website-workgroup/emeriti.yml
+++ b/_data/website-workgroup/emeriti.yml
@@ -2,6 +2,10 @@
   github: krstnfx
   affiliation: Apple
 
+- name: Paris Pittman
+  github: parispittman
+  affiliation: Apple, Core Team rep
+
 - name: Paul Hudson
   github: twostraws
   affiliation:

--- a/_data/website-workgroup/members.yml
+++ b/_data/website-workgroup/members.yml
@@ -13,7 +13,7 @@
 - name: Federico Bucchi
   github: federicobucchi
   affiliation: Apple
-  
+
 - name: James Dempsey
   github: dempseyatgithub
   affiliation:
@@ -21,10 +21,6 @@
 - name: Mishal Shah
   github: shahmishal
   affiliation: Apple
-
-- name: Paris Pittman
-  github: parispittman
-  affiliation: Apple, Core Team rep
 
 - name: Reda Lemeden
   github: kaishin


### PR DESCRIPTION
### Motivation:

Paris left the WWG :-(

### Modifications:

Remove Paris from the WWG page

### Result:

Paris doesn't show in the WWG page
