### PR TITLE
Clarify that `.pkg` installer is required for cross-compilation

### DIFF
--- a/install/macos/index.md
+++ b/install/macos/index.md
@@ -11,14 +11,14 @@ title: Install Swift
   <li class="grid-level-1">
     <h3>Xcode</h3>
     <p class="description">
-      Download the latest version of Xcode, which is regularly refreshed with the latest Swift toolchain.
+      For targeting Darwin platforms, download the latest version of Xcode, which is regularly refreshed with the latest Swift toolchain.
     </p>
     <a href="https://developer.apple.com/xcode/" class="cta-secondary external">Install Xcode</a>
   </li>
   <li class="grid-level-1">
     <h3>Package Installer</h3>
     <p class="description">
-      Toolchain package installer (.pkg)
+      For cross-compilation to non-Darwin platforms and Embedded Swift, download the toolchain package installer (.pkg)
     </p>
     <a href="https://download.swift.org/{{ site.data.builds.swift_releases.last.tag | downcase }}/xcode/{{ site.data.builds.swift_releases.last.tag }}/{{ site.data.builds.swift_releases.last.tag }}-osx.pkg" class="cta-secondary">Download Toolchain</a>
     <a href="/install/macos/package_installer" class="cta-secondary">Instructions</a>


### PR DESCRIPTION
### Motivation:

When cross-compiling on macOS to non-Darwin platforms (Linux or Embedded Swift), `.pkg` installer is required, as it provides necessary tools and has more LLVM backends enabled.

### Modifications:

https://www.swift.org/install/macos/ page now clarifies which installation methods are suitable for each of the use cases.

### Result:

There's less confusion about versions of toolchains necessary for cross-compilation to non-Darwin platforms.
