### PR TITLE
Fix REPL and build instructions in `install/linux/tarball`

### DIFF
--- a/install/linux/tarball/index.md
+++ b/install/linux/tarball/index.md
@@ -107,4 +107,4 @@ This creates a `usr/` directory in the location of the archive.
 $ export PATH=/path/to/usr/bin:"${PATH}"
 ```
 
-You can now execute the `swift` command to run the REPL or build Swift projects.
+You can now execute the `swift repl` command to run the REPL or `swift build` to build Swift packages.


### PR DESCRIPTION
The instructions provided are incorrect: in recent Swift versions the `swift` command won't run the REPL and users need to execute `swift repl` explicitly. Additionally, on non-Darwin platforms users build Swift packages not "Swift projects", the `swift build` command should be utilized for that.