### PR TITLE
Fix broken links on Swift Continuous Integration page

### DIFF
--- a/documentation/continuous-integration/index.md
+++ b/documentation/continuous-integration/index.md
@@ -4,7 +4,7 @@ layout: page
 title: Swift Continuous Integration
 ---
 
-The Swift project follows an [incremental development model](../contributing/#contributing_code), and utilizes continuous integration (CI) testing of changes in pull requests before merging as a core tool for maintaining project stability.  The system produces the snapshot builds posted on swift.org, and runs tests against active branches.  It is also used as part of the review process to run tests against pull requests before committing them.
+The Swift project follows an [incremental development model](/contributing/#contributing-code), and utilizes continuous integration (CI) testing of changes in pull requests before merging as a core tool for maintaining project stability.  The system produces the snapshot builds posted on swift.org, and runs tests against active branches.  It is also used as part of the review process to run tests against pull requests before committing them.
 
 ## Configuration
 
@@ -46,7 +46,7 @@ If there are issues found during testing, you will get a link to the details of 
 
 ![CI Pass](../continuous-integration/images/ci_failure.png)
 
-It is expected that changes meet the [quality standards](../contributing/#quality) for the Swift project before they are committed to the development branch, and you are responsible for fixing problems found by your changes.  If your changes break builds or tests on the development or release branches, you will receive email notification.
+It is expected that changes meet the [quality standards](/contributing/#quality) for the Swift project before they are committed to the development branch, and you are responsible for fixing problems found by your changes.  If your changes break builds or tests on the development or release branches, you will receive email notification.
 
 
 ## Community Involvement


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->



### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

Fixes #884 

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Fixed two links on the page

### Result:

<!-- _[After your change, what will change.]_ -->

- No more broken links! 🙂