### PR TITLE
Add GH Action for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,6 @@ jobs:
           DOWNLOADSWIFTORG_SERVER_NAME: local
         run: |
             docker compose -f ../../docker-compose.yaml run build 
-            docker compose -f ../../docker-compose.yaml start website
+            docker compose -f ../../docker-compose.yaml run -d -p 4000:4000 website
             swift run swiftorgClient
             swift run downloadswiftorgClient

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Run OpenAPI Tester
         working-directory: openapi/TestSwiftOrgClient
+        env:
+          DOWNLOADSWIFTORG_SERVER_NAME: local
         run: |
             docker build -t swift-org-site ../../. 
             docker run -p 4000:4000 -d --name website swift-org-site
-            swift run
+            swift run swiftorgClient
+            swift run downloadswiftorgClient

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,6 @@ jobs:
           DOWNLOADSWIFTORG_SERVER_NAME: local
         run: |
             docker compose -f ../../docker-compose.yaml run build 
-            docker compose -f ../../docker-compose.yaml up website
+            docker compose -f ../../docker-compose.yaml start website
             swift run swiftorgClient
             swift run downloadswiftorgClient

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,7 @@ jobs:
         working-directory: openapi/TestSwiftOrgClient
         env:
           DOWNLOADSWIFTORG_SERVER_NAME: local
+          SWIFTORG_SERVER_NAME: local
         run: |
             docker compose -f ../../docker-compose.yaml run build 
             docker compose -f ../../docker-compose.yaml run -d -p 4000:4000 website

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
         env:
           DOWNLOADSWIFTORG_SERVER_NAME: local
         run: |
-            docker build -t swift-org-site ../../. 
-            docker run -p 4000:4000 -d --name website swift-org-site
+            docker compose -f ../../docker-compose.yaml run build 
+            docker compose -f ../../docker-compose.yaml up website
             swift run swiftorgClient
             swift run downloadswiftorgClient

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,10 +28,12 @@ jobs:
 
   test-openapi:
     runs-on: ubuntu-latest
-    container: swift:6.0
     steps:
       - name: Check out
         uses: actions/checkout@v4
       - name: Run OpenAPI Tester
         working-directory: openapi/TestSwiftOrgClient
-        run: swift run
+        run: |
+            docker build -t swift-org-site ../../. 
+            docker run -p 4000:4000 -d --name website swift-org-site
+            swift run

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,37 @@
+name: test
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+on:
+  pull_request: { types: [opened, reopened, synchronize, ready_for_review] }
+  push: { branches: [ main ] }
+
+jobs:
+  soundness:
+    name: Soundness Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run script
+        run: ./scripts/soundness.sh
+
+  build-site:
+    name: Build the Jekyll Site
+    runs-on: ubuntu-latest
+    container: ruby:3.3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build site
+        run: bundle install && bundle exec jekyll build
+
+  test-openapi:
+    runs-on: ubuntu-latest
+    container: swift:6.0
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+      - name: Run OpenAPI Tester
+        working-directory: openapi/TestSwiftOrgClient
+        run: swift run

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,4 +40,3 @@ jobs:
             docker compose -f ../../docker-compose.yaml run build 
             docker compose -f ../../docker-compose.yaml run -d -p 4000:4000 website
             swift run swiftorgClient
-            swift run downloadswiftorgClient

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,8 +14,6 @@
 # docker-compose up website
 #
 
-version: "2"
-
 services:
 
    docker-setup:

--- a/openapi/TestSwiftOrgClient/Shared/Tester.swift
+++ b/openapi/TestSwiftOrgClient/Shared/Tester.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import Foundation
 
 package struct Test: Sendable {

--- a/openapi/TestSwiftOrgClient/downloadswiftorgClient/Issue847Workaround.swift
+++ b/openapi/TestSwiftOrgClient/downloadswiftorgClient/Issue847Workaround.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import OpenAPIRuntime
 import HTTPTypes
 import Foundation

--- a/openapi/TestSwiftOrgClient/downloadswiftorgClient/Tool.swift
+++ b/openapi/TestSwiftOrgClient/downloadswiftorgClient/Tool.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import OpenAPIURLSession
 import Foundation
 import Shared

--- a/openapi/TestSwiftOrgClient/downloadswiftorgClient/Tool.swift
+++ b/openapi/TestSwiftOrgClient/downloadswiftorgClient/Tool.swift
@@ -18,6 +18,7 @@ import Shared
 
 enum DownloadSwiftOrgServerName: String {
     case prod
+    case local
 }
 
 @main
@@ -31,6 +32,8 @@ struct Tool {
             switch serverName {
             case .prod:
                 serverURL = try Servers.Server1.url()
+            case .local:
+                serverURL = try Servers.Server2.url()
             }
         } else {
             serverURL = try Servers.Server1.url()

--- a/openapi/TestSwiftOrgClient/swiftorgClient/Tool.swift
+++ b/openapi/TestSwiftOrgClient/swiftorgClient/Tool.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift.org project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import OpenAPIURLSession
 import Foundation
 import Shared

--- a/openapi/downloadswiftorg.yaml
+++ b/openapi/downloadswiftorg.yaml
@@ -6,6 +6,8 @@ info:
 servers:
   - url: https://download.swift.org
     description: The production server.
+  - url: http://127.0.0.1:4000/api/v1
+    description: A local deployment.
 tags:
   - name: Evolution
     description: Information about the Swift evolution process.

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][789012]-20[12][89012]/YEARS/' -e 's/20[12][89012]/YEARS/'
+    sed -e 's/20[2][0123456789]-20[2][0123456789]/YEARS/' -e 's/20[2][0123456789]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language... "
@@ -45,11 +45,11 @@ tmp=$(mktemp /tmp/.swift-org-soundness_XXXXXX)
 for language in swift-or-c bash python; do
   declare -a matching_files
   declare -a exceptions
-  expections=( )
+  exceptions=( )
   matching_files=( -name '*' )
   case "$language" in
       swift-or-c)
-        exceptions=( -name "" )
+        exceptions=( -name "Package.swift" )
         matching_files=( -name '*.swift' -o -name '*.c' -o -name '*.h' )
         cat > "$tmp" <<"EOF"
 //===----------------------------------------------------------------------===//
@@ -68,6 +68,7 @@ for language in swift-or-c bash python; do
 EOF
         ;;
       bash)
+        exceptions=( -name "placeholder" )
         matching_files=( -name '*.sh' )
         cat > "$tmp" <<"EOF"
 #!/bin/bash
@@ -87,6 +88,7 @@ EOF
 EOF
       ;;
       python)
+        exceptions=( -name "placeholder" )
         matching_files=( -name '*.py' )
         cat > "$tmp" <<"EOF"
 #!/usr/bin/env python


### PR DESCRIPTION
First steps for adopting GH actions with an action to run on PRs to make sure the site works. This runs:

* the soundness script (which has already picked up an error)
* `jekyll build`
* The OpenAPI test client to ensure the OpenAPI spec works (cc @czechboy0)

@shahmishal can we can actions enabled? I don't know what the original CI was doing, I'm assuming just a Jekyll build