### PR TITLE
Updated Community Showcase packages for February

### DIFF
--- a/_data/packages/packages.yml
+++ b/_data/packages/packages.yml
@@ -9,83 +9,82 @@ categories:
       organised via [this thread in the Swift Forums](https://forums.swift.org/t/68168)
       and curated by the [Swift Website Workgroup](https://www.swift.org/website-workgroup/).
     packages:
-      - name: Queue
-        description: Exposes `AsyncQueue` for managing asynchronous tasks in Swift, ensuring
-          ordered execution without explicit dependencies, and handling errors through
-          an `errorSequence` property.
-        owner: Matt Massicotte
+      - name: CodableWrappers
+        description: Simplify serialization with Property Wrappers. Customize encoding
+          and decoding for Codable types with annotations.
+        owner: GottaGetSwifty
         swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: BSD 3-Clause
-        url: https://swiftpackageindex.com/mattmassicotte/Queue
-        note: Discussed on [Episode 52 of Swift Package Indexing](https://share.transistor.fm/s/687d1170){:target='_blank'}.
-      - name: SwiftCommand
-        description: Wrapper for `Foundation.Process`, inspired by Rust's `std::process::Command`.
-          Facilitates command line program execution and I/O handling using synchronous
-          or `async`/`await` APIs.
-        owner: Josef Zoller
-        swift_compatibility: 5.8+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (macOS) and Linux
-        license: MIT
-        url: https://swiftpackageindex.com/Zollerboy1/SwiftCommand
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/110){:target='_blank'}.
-      - name: SoulverCore
-        description: SoulverCore provides a natural language math engine for calculations,
-          unit conversions, currency rates, and custom functions, with high performance
-          and extensibility.
-        owner: Soulver
-        swift_compatibility: 5.10+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS)
-        license: Unknown license
-        url: https://swiftpackageindex.com/soulverteam/SoulverCore
-        note: Discussed on [Episode 52 of Swift Package Indexing](https://share.transistor.fm/s/687d1170){:target='_blank'}.
-      - name: swift-mustache
-        description: Swift-Mustache enables rendering of Mustache templates, a logic-less
-          templating language. It supports standard Mustache tags, template inheritance,
-          and custom features like transforms, excluding Lambda support.
-        owner: Hummingbird
-        swift_compatibility: 5.8+
         platform_compatibility:
           - Apple
           - Linux
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
           Linux
         license: Apache 2.0
-        url: https://swiftpackageindex.com/hummingbird-project/swift-mustache
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/107){:target='_blank'}.
-      - name: ColorToolbox
-        description: ColorToolbox provides Swift color utilities for UIKit, AppKit, and
-          SwiftUI. It includes features such as converting from and to hex strings, calculating
-          relative luminance and WCAG contrast ratio, and lightening/darkening colors.
-        owner: Ramon Torres
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-        license: MIT
-        url: https://swiftpackageindex.com/raymondjavaxx/ColorToolbox
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/114){:target='_blank'}.
-      - name: Orb
-        description: SwiftUI component for creating customizable animated orbs with effects
-          like glowing, particles, and dynamic animations, inspired by Siri animations.
-          Ideal for interactive and visually appealing UI designs.
-        owner: Siddhant Mehta
+        url: https://swiftpackageindex.com/GottaGetSwifty/CodableWrappers
+        note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/116){:target='_blank'}.
+      - name: Forked
+        description: Manages shared data by preventing data races and race conditions,
+          using a decentralized model for branching and merging. Supports custom data
+          types, advanced merging, and iCloud synchronization.
+        owner: Drew McCormack
         swift_compatibility: 6.0+
         platform_compatibility:
           - Apple
-        platform_compatibility_tooltip: Apple (iOS, visionOS, tvOS)
+          - Linux
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: MIT
-        url: https://swiftpackageindex.com/metasidd/Orb
-        note: Discussed on [Episode 52 of Swift Package Indexing](https://share.transistor.fm/s/687d1170){:target='_blank'}.
+        url: https://swiftpackageindex.com/drewmccormack/Forked
+        note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/119){:target='_blank'}.
+      - name: SwiftSessions
+        description: Swift Sessions provides session types for structured communication
+          in concurrent systems, featuring session type inference, binary branches, dynamic
+          linearity checking, and client/server architecture support.
+        owner: Alessio Rubicini
+        swift_compatibility: 5.10+
+        platform_compatibility:
+          - Apple
+          - Linux
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
+        license: MIT
+        url: https://swiftpackageindex.com/alessiorubicini/SwiftSessions
+        note: Discussed on [Episode 46 of Swift Package Indexing](https://share.transistor.fm/s/08c0a3f9){:target='_blank'}.
+      - name: ControlKit
+        description: ControlKit enables media playback control and device volume adjustment.
+          It supports Spotify integration with authentication through a custom URL scheme
+          and requires a Spotify client ID.
+        owner: Ryan F
+        swift_compatibility: 5.10+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS)
+        license: MIT
+        url: https://swiftpackageindex.com/superturboryan/ControlKit
+        note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/95){:target='_blank'}.
+      - name: Scipio
+        description: Scipio facilitates dependency management by converting Swift packages
+          into XCFrameworks, ensuring efficient caching and portability. Inspired by Carthage,
+          it merges SwiftPM and XCFramework benefits.
+        owner: Kohki Miki
+        swift_compatibility: 6.0+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (macOS)
+        license: MIT
+        url: https://swiftpackageindex.com/giginet/Scipio
+        note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/118){:target='_blank'}.
+      - name: SwiftUIFX
+        description: Enhances Final Cut Pro by integrating SwiftUI views as video overlays,
+          allowing dynamic visual content creation and manipulation through a Swift package.
+        owner: Finn Voorhees
+        swift_compatibility: 6.0+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (macOS)
+        license: CC Zero 1.0
+        url: https://swiftpackageindex.com/finnvoor/SwiftUIFX
+        note: Linked to in [Issue 688 of iOS Dev Weekly](https://iosdevweekly.com/issues/688#4ItU5lq){:target='_blank'}.
   - name: Packages with Macros
     slug: macros
     brief: New in Swift 5.9, Swift packages can include macro targets. Browse a selection

--- a/_data/packages/showcase-history.yml
+++ b/_data/packages/showcase-history.yml
@@ -1,5 +1,5 @@
 years:
-  - year: 2024
+  - year: 2025
     months:
       - month: January
         slug: january
@@ -82,6 +82,8 @@ years:
             license: MIT
             url: https://swiftpackageindex.com/metasidd/Orb
             note: Discussed on [Episode 52 of Swift Package Indexing](https://share.transistor.fm/s/687d1170){:target='_blank'}.
+  - year: 2024
+    months:
       - month: December
         slug: december
         packages:

--- a/_data/packages/showcase-history.yml
+++ b/_data/packages/showcase-history.yml
@@ -1,6 +1,87 @@
 years:
   - year: 2024
     months:
+      - month: January
+        slug: january
+        packages:
+          - name: Queue
+            description: Exposes `AsyncQueue` for managing asynchronous tasks in Swift,
+              ensuring ordered execution without explicit dependencies, and handling errors
+              through an `errorSequence` property.
+            owner: Matt Massicotte
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: BSD 3-Clause
+            url: https://swiftpackageindex.com/mattmassicotte/Queue
+            note: Discussed on [Episode 52 of Swift Package Indexing](https://share.transistor.fm/s/687d1170){:target='_blank'}.
+          - name: SwiftCommand
+            description: Wrapper for `Foundation.Process`, inspired by Rust's `std::process::Command`.
+              Facilitates command line program execution and I/O handling using synchronous
+              or `async`/`await` APIs.
+            owner: Josef Zoller
+            swift_compatibility: 5.8+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (macOS) and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/Zollerboy1/SwiftCommand
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/110){:target='_blank'}.
+          - name: SoulverCore
+            description: SoulverCore provides a natural language math engine for calculations,
+              unit conversions, currency rates, and custom functions, with high performance
+              and extensibility.
+            owner: Soulver
+            swift_compatibility: 5.10+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS)
+            license: Unknown license
+            url: https://swiftpackageindex.com/soulverteam/SoulverCore
+            note: Discussed on [Episode 52 of Swift Package Indexing](https://share.transistor.fm/s/687d1170){:target='_blank'}.
+          - name: swift-mustache
+            description: Swift-Mustache enables rendering of Mustache templates, a logic-less
+              templating language. It supports standard Mustache tags, template inheritance,
+              and custom features like transforms, excluding Lambda support.
+            owner: Hummingbird
+            swift_compatibility: 5.8+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/hummingbird-project/swift-mustache
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/107){:target='_blank'}.
+          - name: ColorToolbox
+            description: ColorToolbox provides Swift color utilities for UIKit, AppKit,
+              and SwiftUI. It includes features such as converting from and to hex strings,
+              calculating relative luminance and WCAG contrast ratio, and lightening/darkening
+              colors.
+            owner: Ramon Torres
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/raymondjavaxx/ColorToolbox
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/114){:target='_blank'}.
+          - name: Orb
+            description: SwiftUI component for creating customizable animated orbs with
+              effects like glowing, particles, and dynamic animations, inspired by Siri
+              animations. Ideal for interactive and visually appealing UI designs.
+            owner: Siddhant Mehta
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, visionOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/metasidd/Orb
+            note: Discussed on [Episode 52 of Swift Package Indexing](https://share.transistor.fm/s/687d1170){:target='_blank'}.
       - month: December
         slug: december
         packages:
@@ -1059,9 +1140,9 @@ years:
             url: https://swiftpackageindex.com/automerge/automerge-swift
             note: Discussed on [Episode 36 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/36-even-though-the-bug-is-fixed-its-not-over){:target='_blank'}.
           - name: Grape
-            description: Grape enables graph visualization and force simulation in Swift,
-              supporting force-directed graphs and customizable simulations with modules
-              for SwiftUI Views and performance-optimized force calculations.
+            description: Grape is a Swift library for force simulation and graph visualization.
+              It provides classes for creating simulations and forces and supports both
+              2D and 3D graphs.
             owner: Swift Graphs
             swift_compatibility: 6.0+
             platform_compatibility:

--- a/_data/packages/showcase-history.yml
+++ b/_data/packages/showcase-history.yml
@@ -1142,9 +1142,9 @@ years:
             url: https://swiftpackageindex.com/automerge/automerge-swift
             note: Discussed on [Episode 36 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/36-even-though-the-bug-is-fixed-its-not-over){:target='_blank'}.
           - name: Grape
-            description: Grape is a Swift library for force simulation and graph visualization.
-              It provides classes for creating simulations and forces and supports both
-              2D and 3D graphs.
+            description: Grape enables graph visualization and force simulation in Swift,
+              supporting force-directed graphs and customizable simulations with modules
+              for SwiftUI Views and performance-optimized force calculations.
             owner: Swift Graphs
             swift_compatibility: 6.0+
             platform_compatibility:


### PR DESCRIPTION
This update contains the [Community Showcase packages](https://www.swift.org/packages/showcase.html) for February.

Packages in the Community Showcase are nominated by the community in [this thread on the Swift forums](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168) and voted on by the [SWWG](https://www.swift.org/website-workgroup/).

![Screenshot 2025-02-05 at 17 51 32@2x](https://github.com/user-attachments/assets/b86d092d-c8a3-4529-a7e2-db56b69ada45)
