### PR TITLE
Add "OpenAPI integration with DocC" GSoC project idea

### DIFF
--- a/gsoc2025/index.md
+++ b/gsoc2025/index.md
@@ -303,6 +303,38 @@ Enhance Swift Testing's reporting of test results to the console/terminal. Consi
 
 - [Stuart Montgomery](https://github.com/stmontgomery)
 
+### OpenAPI integration with DocC
+
+**Project size**: 350 hours (large)
+
+**Estimated difficulty**: Intermediate
+
+**Recommended skills**
+
+- Basic proficiency in Swift.
+- Basic knowledge in HTTP APIs.
+
+**Description**
+
+[OpenAPI](https://www.openapis.org/) is a standard for documenting HTTP services. It allows creating documents in YAML or JSON format that can be utilized by various tools to automate workflows, such as generating the required code for sending and receiving HTTP requests.
+
+OpenAPI is known for its tooling to generate documentation, but in the Swift ecosystem, developers are already familiar with how [DocC](https://github.com/swiftlang/swift-docc) renders documentation for Swift and Objective-C APIs. To enhance consistency and improve the developer experience, we aim to extend DocC’s support to OpenAPI documents.
+
+**Expected outcomes/benefits/deliverables**
+
+As part of the Google Summer of Code project, the student will develop a library/tool that can generate DocC documentation from an OpenAPI document.
+
+Strech goals:
+
+* Integrate the tool into the [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
+* Create OpenAPI Doc to DocC Live Preview plugin for VS Code.
+
+**Potential mentors**
+
+- [Sofía Rodríguez](https://github.com/sofiaromorales)
+- [Si Beaumont](https://github.com/simonjbeaumont)
+- [Honza Dvorsky](https://github.com/czechboy0)
+
 ### Example project name
 
 **Project size**: N hours


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

This change adds a "OpenAPI integration with DocC" project idea to the GSoC page.

### Motivation:

The Swift ecosystem already offers tooling for OpenAPI. This project explores expanding that support by incorporating DocC for OpenAPI documentation.

### Modifications:

Project added to the list of GSoC ideas.

### Result:

New project on the GSoC25 list page.