### PR TITLE
Fix vscode-swfft Create Issue link

### DIFF
--- a/_posts/2022-07-14-vscode-extension.md
+++ b/_posts/2022-07-14-vscode-extension.md
@@ -60,4 +60,4 @@ You can also use container support with the nightly Swift Docker images to test 
 
 The extension includes the core set of features we initially planned for, but we are not finished and will continue to expand on what we have. While much of the work initially was done by the SSWG, this is a community project and we are happy to involve anyone interested in contributing.
 
-If you feel something is missing or broken, please add an [Issue](https://github.com/swift-server/vscode-swift/issues). If you can contribute time to building new features or fixing bugs, please get in touch.
+If you feel something is missing or broken, please add an [Issue](https://github.com/swiftlang/vscode-swift/issues). If you can contribute time to building new features or fixing bugs, please get in touch.


### PR DESCRIPTION
Fixup the link now that vscode-swift has moved to swiftlang.
