### PR TITLE
Update swiftly release to 0.4.0

### DIFF
--- a/_data/builds/swiftly_release.yml
+++ b/_data/builds/swiftly_release.yml
@@ -1,8 +1,8 @@
-version: "0.4.0-dev"
+version: "0.4.0"
 platforms:
   - platform: Linux
-    x86_64: "https://download.swift.org/swiftly/linux/swiftly-0.4.0-dev-x86_64.tar.gz"
-    arm64: "https://download.swift.org/swiftly/linux/swiftly-0.4.0-dev-aarch64.tar.gz"
+    x86_64: "https://download.swift.org/swiftly/linux/swiftly-0.4.0-x86_64.tar.gz"
+    arm64: "https://download.swift.org/swiftly/linux/swiftly-0.4.0-aarch64.tar.gz"
   - platform: Darwin
-    x86_64: "https://download.swift.org/swiftly/darwin/swiftly-0.4.0-dev.pkg"
-    arm64: "https://download.swift.org/swiftly/darwin/swiftly-0.4.0-dev.pkg"
+    x86_64: "https://download.swift.org/swiftly/darwin/swiftly-0.4.0.pkg"
+    arm64: "https://download.swift.org/swiftly/darwin/swiftly-0.4.0.pkg"


### PR DESCRIPTION
Now that the swiftly 0.4.0 release has been published, update the swiftly_release API to the new version.