### PR TITLE
Provide installation CLI command on `package_installer` page

### DIFF
--- a/install/macos/package_installer/index.md
+++ b/install/macos/package_installer/index.md
@@ -25,7 +25,11 @@ Package Manager may be limited due to some [outstanding issues](https://github.c
 
 0. Run the package installer,
    which will install an Xcode toolchain into
-   `/Library/Developer/Toolchains/`.
+   `~/Library/Developer/Toolchains/`:
+
+    ~~~ shell
+    installer -target CurrentUserHomeDirectory -pkg ~/Downloads/swift-DEVELOPMENT-SNAPSHOT-2025-02-26-a-osx.pkg
+    ~~~
 
    An Xcode toolchain (`.xctoolchain`) includes a copy of the compiler, LLDB,
    and other related tools needed to provide a cohesive development experience


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

Current macOS installation instructions recommend using a global system path instead of home user directory, which may require admin privileges that aren't always available. Additionally, it assumes that a multi-step installer GUI will run, but no guidance for that installer is provided.

We should prefer installing into user's home directory and provide instructions that require as little manual intervention as possible.

### Modifications:

A CLI command is listed that automatically installs into user's home directory, not requiring admin privileges, and also avoid running a multi-step GUI installer.

### Result:

Instructions are easier to run and require less manual steps.
