### PR TITLE
Fix path for TOOLCHAINS environment variable in `package_installer` page

### DIFF
--- a/install/macos/package_installer/index.md
+++ b/install/macos/package_installer/index.md
@@ -56,7 +56,7 @@ Package Manager may be limited due to some [outstanding issues](https://github.c
   the `TOOLCHAINS` environment variable as follows:
 
   ~~~ shell
-  export TOOLCHAINS=$(plutil -extract CFBundleIdentifier raw /Library/Developer/Toolchains/<toolchain name>.xctoolchain/Info.plist)
+  export TOOLCHAINS=$(plutil -extract CFBundleIdentifier raw ~/Library/Developer/Toolchains/<toolchain name>.xctoolchain/Info.plist)
   ~~~
 
 


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

Completes the installation path update started in #922.

### Modifications:

Changed the toolchain path in documentation from:
`/Library/Developer/Toolchains/<toolchain name>.xctoolchain` 
to 
`~/Library/Developer/Toolchains/<toolchain name>.xctoolchain`

### Result:

Ensures full consistency with #922. The toolchain path now correctly matches the actual installation location.
