### PR TITLE
fix project size for DocC language features GSoC project idea

### DIFF
--- a/gsoc2025/index.md
+++ b/gsoc2025/index.md
@@ -194,7 +194,7 @@ Qualified name lookup is the process by which a compiler resolves a reference  `
 
 ### DocC Language Features in SourceKit-LSP
 
-**Project size**: 90 hours (medium)
+**Project size**: 175 hours (medium)
 
 **Estimated difficulty**: Intermediate
 


### PR DESCRIPTION
The project size for the DocC language features says medium, but lists a 90 hour completion time. Adjust this to 175 hours to be in line with a medium project size.