### PR TITLE
Updated Community Showcase packages for March

### DIFF
--- a/_data/packages/packages.yml
+++ b/_data/packages/packages.yml
@@ -9,82 +9,55 @@ categories:
       organised via [this thread in the Swift Forums](https://forums.swift.org/t/68168)
       and curated by the [Swift Website Workgroup](https://www.swift.org/website-workgroup/).
     packages:
-      - name: CodableWrappers
-        description: Simplify serialization with Property Wrappers. Customize encoding
-          and decoding for Codable types with annotations.
-        owner: GottaGetSwifty
+      - name: FileMonitor
+        description: FileMonitor provides a unified API to detect file changes in a directory
+          on Linux and macOS. It detects file creations, modifications, and deletions
+          and then propagates events through a delegate function.
+        owner: aus der Technik - Simon & Simon GbR
         swift_compatibility: 5.9+
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
+        platform_compatibility_tooltip: Apple (macOS) and Linux
+        license: MIT
+        url: https://swiftpackageindex.com/aus-der-Technik/FileMonitor
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/125){:target='_blank'}.
+      - name: Versionator
+        description: A plugin to gathers version information and embeds it into a package/executable,
+          allowing retrieval at runtime. Generates `Version.swift`, `Info.plist`, and
+          a header file.
+        owner: Elegant Chaos
+        swift_compatibility: 6.0+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (macOS)
+        license: MIT
+        url: https://swiftpackageindex.com/elegantchaos/Versionator
+        note: Discussed on [Episode 49 of Swift Package Indexing](https://share.transistor.fm/s/c3ea4e1a){:target='_blank'}.
+      - name: Numerix
+        description: Provides Complex, Vector, Matrix, and ShapedArray structures for
+          linear algebra and numerical computations using the Accelerate framework for
+          high-performance calculations.
+        owner: Gavin Wiggins
+        swift_compatibility: 6.0+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+        license: MIT
+        url: https://swiftpackageindex.com/wigging/numerix
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/119){:target='_blank'}.
+      - name: swift-zip-archive
+        description: A library for reading and editing zip archives. Supports reading
+          and writing standard or password protected zip files from disk and memory buffers.
+        owner: Adam Fowler
+        swift_compatibility: 6.0+
+        platform_compatibility:
+          - Apple
+          - Linux
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS) and Linux
         license: Apache 2.0
-        url: https://swiftpackageindex.com/GottaGetSwifty/CodableWrappers
-        note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/116){:target='_blank'}.
-      - name: Forked
-        description: Manages shared data by preventing data races and race conditions,
-          using a decentralized model for branching and merging. Supports custom data
-          types, advanced merging, and iCloud synchronization.
-        owner: Drew McCormack
-        swift_compatibility: 6.0+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: MIT
-        url: https://swiftpackageindex.com/drewmccormack/Forked
-        note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/119){:target='_blank'}.
-      - name: SwiftSessions
-        description: Swift Sessions provides session types for structured communication
-          in concurrent systems, featuring session type inference, binary branches, dynamic
-          linearity checking, and client/server architecture support.
-        owner: Alessio Rubicini
-        swift_compatibility: 5.10+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: MIT
-        url: https://swiftpackageindex.com/alessiorubicini/SwiftSessions
-        note: Discussed on [Episode 46 of Swift Package Indexing](https://share.transistor.fm/s/08c0a3f9){:target='_blank'}.
-      - name: ControlKit
-        description: ControlKit enables media playback control and device volume adjustment.
-          It supports Spotify integration with authentication through a custom URL scheme
-          and requires a Spotify client ID.
-        owner: Ryan F
-        swift_compatibility: 5.10+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS)
-        license: MIT
-        url: https://swiftpackageindex.com/superturboryan/ControlKit
-        note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/95){:target='_blank'}.
-      - name: Scipio
-        description: Scipio facilitates dependency management by converting Swift packages
-          into XCFrameworks, ensuring efficient caching and portability. Inspired by Carthage,
-          it merges SwiftPM and XCFramework benefits.
-        owner: Kohki Miki
-        swift_compatibility: 6.0+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (macOS)
-        license: MIT
-        url: https://swiftpackageindex.com/giginet/Scipio
-        note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/118){:target='_blank'}.
-      - name: SwiftUIFX
-        description: Enhances Final Cut Pro by integrating SwiftUI views as video overlays,
-          allowing dynamic visual content creation and manipulation through a Swift package.
-        owner: Finn Voorhees
-        swift_compatibility: 6.0+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (macOS)
-        license: CC Zero 1.0
-        url: https://swiftpackageindex.com/finnvoor/SwiftUIFX
-        note: Linked to in [Issue 688 of iOS Dev Weekly](https://iosdevweekly.com/issues/688#4ItU5lq){:target='_blank'}.
+        url: https://swiftpackageindex.com/adam-fowler/swift-zip-archive
+        note: Discussed on [Episode 53 of Swift Package Indexing](https://share.transistor.fm/s/56a29e9f){:target='_blank'}.
   - name: Packages with Macros
     slug: macros
     brief: New in Swift 5.9, Swift packages can include macro targets. Browse a selection

--- a/_data/packages/showcase-history.yml
+++ b/_data/packages/showcase-history.yml
@@ -1,6 +1,86 @@
 years:
   - year: 2025
     months:
+      - month: February
+        slug: february
+        packages:
+          - name: CodableWrappers
+            description: Simplify serialization with Property Wrappers. Customize encoding
+              and decoding for Codable types with annotations.
+            owner: GottaGetSwifty
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/GottaGetSwifty/CodableWrappers
+            note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/116){:target='_blank'}.
+          - name: Forked
+            description: Manages shared data by preventing data races and race conditions,
+              using a decentralized model for branching and merging. Supports custom data
+              types, advanced merging, and iCloud synchronization.
+            owner: Drew McCormack
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/drewmccormack/Forked
+            note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/119){:target='_blank'}.
+          - name: SwiftSessions
+            description: Swift Sessions provides session types for structured communication
+              in concurrent systems, featuring session type inference, binary branches,
+              dynamic linearity checking, and client/server architecture support.
+            owner: Alessio Rubicini
+            swift_compatibility: 5.10+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/alessiorubicini/SwiftSessions
+            note: Discussed on [Episode 46 of Swift Package Indexing](https://share.transistor.fm/s/08c0a3f9){:target='_blank'}.
+          - name: ControlKit
+            description: ControlKit enables media playback control and device volume adjustment.
+              It supports Spotify integration with authentication through a custom URL scheme
+              and requires a Spotify client ID.
+            owner: Ryan F
+            swift_compatibility: 5.10+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS)
+            license: MIT
+            url: https://swiftpackageindex.com/superturboryan/ControlKit
+            note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/95){:target='_blank'}.
+          - name: Scipio
+            description: Scipio facilitates dependency management by converting Swift packages
+              into XCFrameworks, ensuring efficient caching and portability. Inspired by
+              Carthage, it merges SwiftPM and XCFramework benefits.
+            owner: Kohki Miki
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (macOS)
+            license: MIT
+            url: https://swiftpackageindex.com/giginet/Scipio
+            note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/118){:target='_blank'}.
+          - name: SwiftUIFX
+            description: Enhances Final Cut Pro by integrating SwiftUI views as video overlays,
+              allowing dynamic visual content creation and manipulation through a Swift
+              package.
+            owner: Finn Voorhees
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (macOS)
+            license: CC Zero 1.0
+            url: https://swiftpackageindex.com/finnvoor/SwiftUIFX
+            note: Linked to in [Issue 688 of iOS Dev Weekly](https://iosdevweekly.com/issues/688#4ItU5lq){:target='_blank'}.
       - month: January
         slug: january
         packages:


### PR DESCRIPTION
This update contains the [Community Showcase packages](https://www.swift.org/packages/showcase.html) for March.

Packages in the Community Showcase are nominated by the community in [this thread on the Swift forums](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168) and voted on by the [SWWG](https://www.swift.org/website-workgroup/).

![Screenshot 2025-03-17 at 19 49 25@2x](https://github.com/user-attachments/assets/edd1fbf0-d32f-4877-9563-cf38578e36cb)
