### PR TITLE
Permit freeform source branch and platform identifiers in OpenAPI spec

### DIFF
--- a/openapi/TestSwiftOrgClient/swiftorgClient/Tool.swift
+++ b/openapi/TestSwiftOrgClient/swiftorgClient/Tool.swift
@@ -60,8 +60,8 @@ struct Tool {
                         work: {
                             _ = try await client.listDevToolchains(.init(
                                 path: .init(
-                                    branch: branch,
-                                    platform: platform
+                                    branch: .init(value1: branch),
+                                    platform: .init(value1: platform)
                                 )
                             )).ok.body.json
                         }
@@ -74,7 +74,7 @@ struct Tool {
                 .init(
                     name: "listStaticSDKDevToolchains(\(branch.rawValue))",
                     work: {
-                        _ = try await client.listStaticSDKDevToolchains(.init(path: .init(branch: branch))).ok.body.json
+                        _ = try await client.listStaticSDKDevToolchains(.init(path: .init(branch: .init(value1: branch)))).ok.body.json
                     }
                 )
             )

--- a/openapi/swiftorg.yaml
+++ b/openapi/swiftorg.yaml
@@ -37,12 +37,12 @@ paths:
         in: path
         required: true
         schema:
-          $ref: '#/components/schemas/KnownSourceBranch'
+          $ref: '#/components/schemas/SourceBranch'
       - name: platform
         in: path
         required: true
         schema:
-          $ref: '#/components/schemas/KnownPlatformIdentifier'
+          $ref: '#/components/schemas/PlatformIdentifier'
     get:
       operationId: listDevToolchains
       summary: Fetch all development toolchains
@@ -61,7 +61,7 @@ paths:
         in: path
         required: true
         schema:
-          $ref: '#/components/schemas/KnownSourceBranch'
+          $ref: '#/components/schemas/SourceBranch'
     get:
       operationId: listStaticSDKDevToolchains
       summary: Fetch all static SDK development toolchains


### PR DESCRIPTION
When using the current OpenAPI specification for discovering snapshot toolchains
in an OpenAPI generator, there is a code-level limitation on the known branches
(e.g. main or 6.0), and the known platform identifiers (e.g. macOS, amazonlinux2).
These values will change over time and new snapshot branches come (e.g. 6.1, or 7.0)
and platforms are added (e.g. "ubuntu2404"). Clients that are based on earlier versions
of the schema should remain compatible, and permit user input of new values that they
know to exist. That's not possible currently.

This change will adjust the schema to take advantage of the schema types that allow a
choice of a known value, and ones that are not (yet) known to the schema.