### PR TITLE
Update swiftly install one-liner and instructions

### DIFF
--- a/_includes/install/_linux_platforms_tabs.md
+++ b/_includes/install/_linux_platforms_tabs.md
@@ -8,8 +8,8 @@
   <h4>Run this in a terminal:</h4>
   <div class="language-plaintext highlighter-rouge"><div class="highlight"><button>Copy</button><pre class="highlight"><code>curl -O https://download.swift.org/swiftly/linux/swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz &amp;&amp; \
 tar zxf swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz &amp;&amp; \
-SWIFTLY_HOME_DIR=~/.swiftly SWIFTLY_BIN_DIR=~/.swiftly/bin ./swiftly init --quiet-shell-followup &amp;&amp; \
-. ~/.swiftly/env.sh &amp;&amp; \
+./swiftly init --quiet-shell-followup &amp;&amp; \
+. ~/.local/share/swiftly/env.sh &amp;&amp; \
 hash -r
 </code></pre></div></div>
   <h4>License: <a href="https://raw.githubusercontent.com/swiftlang/swiftly/refs/heads/main/LICENSE.txt">Apache-2.0</a> | PGP: <a href="https://download.swift.org/swiftly/linux/swiftly-0.4.0-dev-x86_64.tar.gz.sig">Signature</a></h4>

--- a/_includes/install/_linux_platforms_tabs.md
+++ b/_includes/install/_linux_platforms_tabs.md
@@ -8,8 +8,8 @@
   <h4>Run this in a terminal:</h4>
   <div class="language-plaintext highlighter-rouge"><div class="highlight"><button>Copy</button><pre class="highlight"><code>curl -O https://download.swift.org/swiftly/linux/swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz &amp;&amp; \
 tar zxf swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz &amp;&amp; \
-./swiftly init --quiet-shell-followup &amp;&amp; \
-. ~/.local/share/swiftly/env.sh &amp;&amp; \
+SWIFTLY_HOME_DIR=~/.swiftly SWIFTLY_BIN_DIR=~/.swiftly/bin ./swiftly init --quiet-shell-followup &amp;&amp; \
+. ~/.swiftly/env.sh &amp;&amp; \
 hash -r
 </code></pre></div></div>
   <h4>License: <a href="https://raw.githubusercontent.com/swiftlang/swiftly/refs/heads/main/LICENSE.txt">Apache-2.0</a> | PGP: <a href="https://download.swift.org/swiftly/linux/swiftly-0.4.0-dev-x86_64.tar.gz.sig">Signature</a></h4>

--- a/install/linux/swiftly/index.md
+++ b/install/linux/swiftly/index.md
@@ -26,7 +26,7 @@ tar -zxf swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.
 Run the following command in your terminal, to configure swiftly for your account, and automatically download the latest swift toolchain.
 
 ```
-./swiftly init
+SWIFTLY_HOME_DIR=~/.swiftly SWIFTLY_BIN_DIR=~/.swiftly/bin ./swiftly init
 ```
 
 Your current shell may need some additional steps to update your session. Follow the guidance at the end of the installation for a smooth install experience, such as sourcing the environment file, and rehashing your shell's PATH.

--- a/install/linux/swiftly/index.md
+++ b/install/linux/swiftly/index.md
@@ -29,7 +29,7 @@ Run the following command in your terminal, to configure swiftly for your accoun
 SWIFTLY_HOME_DIR=~/.swiftly SWIFTLY_BIN_DIR=~/.swiftly/bin ./swiftly init
 ```
 
-Note: You can adjust the SWIFTLY_* environment variables to customize the install location, or remove them entirely to a Linux standard location.
+Note: You can adjust the SWIFTLY_* environment variables to customize your install location, or remove them entirely to get the Linux standard location.
 
 Your current shell may need some additional steps to update your session. Follow the guidance at the end of the installation for a smooth install experience, such as sourcing the environment file, and rehashing your shell's PATH.
 

--- a/install/linux/swiftly/index.md
+++ b/install/linux/swiftly/index.md
@@ -29,6 +29,8 @@ Run the following command in your terminal, to configure swiftly for your accoun
 SWIFTLY_HOME_DIR=~/.swiftly SWIFTLY_BIN_DIR=~/.swiftly/bin ./swiftly init
 ```
 
+Note: You can adjust the SWIFTLY_* environment variables to customize the install location, or remove them entirely to a Linux standard location.
+
 Your current shell may need some additional steps to update your session. Follow the guidance at the end of the installation for a smooth install experience, such as sourcing the environment file, and rehashing your shell's PATH.
 
 There can be certain packages that need to be installed on your system so that the Swift toolchain can function. The swiftly initialization routine will show you how to install any missing packages.

--- a/install/linux/swiftly/index.md
+++ b/install/linux/swiftly/index.md
@@ -26,10 +26,10 @@ tar -zxf swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.
 Run the following command in your terminal, to configure swiftly for your account, and automatically download the latest swift toolchain.
 
 ```
-SWIFTLY_HOME_DIR=~/.swiftly SWIFTLY_BIN_DIR=~/.swiftly/bin ./swiftly init
+./swiftly init
 ```
 
-Note: You can adjust the SWIFTLY_* environment variables to customize your install location, or remove them entirely to get the Linux standard location.
+Note: You can set the SWIFTLY_HOME_DIR and SWIFTLY_BIN_DIR environment variables to customize your install location.
 
 Your current shell may need some additional steps to update your session. Follow the guidance at the end of the installation for a smooth install experience, such as sourcing the environment file, and rehashing your shell's PATH.
 

--- a/install/macos/index.md
+++ b/install/macos/index.md
@@ -15,7 +15,7 @@ title: Install Swift
   <h4>Run this in a terminal:</h4>
   <div class="language-plaintext highlighter-rouge"><div class="highlight"><button>Copy</button><pre class="highlight"><code>curl -O https://download.swift.org/swiftly/darwin/swiftly-{{ site.data.builds.swiftly_release.version }}.pkg &amp;&amp; \
 installer -pkg swiftly-{{ site.data.builds.swiftly_release.version }}.pkg -target CurrentUserHomeDirectory &amp;&amp; \
-SWIFTLY_HOME_DIR=~/.swiftly SWIFTLY_BIN_DIR=~/.swiftly/bin ~/.swiftly/bin/swiftly init --quiet-shell-followup &amp;&amp; \
+~/.swiftly/bin/swiftly init --quiet-shell-followup &amp;&amp; \
 . ~/.swiftly/env.sh &amp;&amp; \
 hash -r
 </code></pre></div></div>

--- a/install/macos/index.md
+++ b/install/macos/index.md
@@ -15,8 +15,8 @@ title: Install Swift
   <h4>Run this in a terminal:</h4>
   <div class="language-plaintext highlighter-rouge"><div class="highlight"><button>Copy</button><pre class="highlight"><code>curl -O https://download.swift.org/swiftly/darwin/swiftly-{{ site.data.builds.swiftly_release.version }}.pkg &amp;&amp; \
 installer -pkg swiftly-{{ site.data.builds.swiftly_release.version }}.pkg -target CurrentUserHomeDirectory &amp;&amp; \
-~/usr/local/bin/swiftly init --quiet-shell-followup &amp;&amp; \
-. ~/Library/Application\ Support/swiftly/env.sh &amp;&amp; \
+SWIFTLY_HOME_DIR=~/.swiftly SWIFTLY_BIN_DIR=~/.swiftly/bin ~/.swiftly/bin/swiftly init --quiet-shell-followup &amp;&amp; \
+. ~/.swiftly/env.sh &amp;&amp; \
 hash -r
 </code></pre></div></div>
   <h4>License: <a href="https://raw.githubusercontent.com/swiftlang/swiftly/refs/heads/main/LICENSE.txt">Apache-2.0</a></h4>

--- a/install/macos/swiftly/index.md
+++ b/install/macos/swiftly/index.md
@@ -14,10 +14,10 @@ installer -pkg swiftly-{{ site.data.builds.swiftly_release.version }}.pkg -targe
 Run the following command in your terminal, to configure swiftly for your account, and automatically download the latest swift toolchain.
 
 ```
-SWIFTLY_HOME_DIR=~/.swiftly SWIFTLY_BIN_DIR=~/.swiftly/bin ~/.swiftly/bin/swiftly init
+~/.swiftly/bin/swiftly init
 ```
 
-Note: You can change the SWIFTLY_* environment variables to customize the install location, or remove them entirely to get the macOS standard location.
+Note: You can set the SWIFTLY_HOME_DIR and SWIFTLY_BIN_DIR environment variables to customize the install location.
 
 <div class="warning" markdown="1">
 Your current shell may need some additional steps to update your session. Follow the guidance at the end of the installation for a smooth install experience, such as sourcing the environment file, and rehashing your shell's PATH.

--- a/install/macos/swiftly/index.md
+++ b/install/macos/swiftly/index.md
@@ -17,6 +17,8 @@ Run the following command in your terminal, to configure swiftly for your accoun
 SWIFTLY_HOME_DIR=~/.swiftly SWIFTLY_BIN_DIR=~/.swiftly/bin ~/.swiftly/bin/swiftly init
 ```
 
+Note: You can change the SWIFTLY_* environment variables to customize the install location, or remove them to use a macOS standard location.
+
 <div class="warning" markdown="1">
 Your current shell may need some additional steps to update your session. Follow the guidance at the end of the installation for a smooth install experience, such as sourcing the environment file, and rehashing your shell's PATH.
 </div>

--- a/install/macos/swiftly/index.md
+++ b/install/macos/swiftly/index.md
@@ -17,7 +17,7 @@ Run the following command in your terminal, to configure swiftly for your accoun
 SWIFTLY_HOME_DIR=~/.swiftly SWIFTLY_BIN_DIR=~/.swiftly/bin ~/.swiftly/bin/swiftly init
 ```
 
-Note: You can change the SWIFTLY_* environment variables to customize the install location, or remove them to use a macOS standard location.
+Note: You can change the SWIFTLY_* environment variables to customize the install location, or remove them entirely to get the macOS standard location.
 
 <div class="warning" markdown="1">
 Your current shell may need some additional steps to update your session. Follow the guidance at the end of the installation for a smooth install experience, such as sourcing the environment file, and rehashing your shell's PATH.

--- a/install/macos/swiftly/index.md
+++ b/install/macos/swiftly/index.md
@@ -14,7 +14,7 @@ installer -pkg swiftly-{{ site.data.builds.swiftly_release.version }}.pkg -targe
 Run the following command in your terminal, to configure swiftly for your account, and automatically download the latest swift toolchain.
 
 ```
-~/usr/local/bin/swiftly init
+SWIFTLY_HOME_DIR=~/.swiftly SWIFTLY_BIN_DIR=~/.swiftly/bin ~/.swiftly/bin/swiftly init
 ```
 
 <div class="warning" markdown="1">


### PR DESCRIPTION
The macOS installer puts swiftly in a different location now that's more understandable.

Update the instructions to reflect the new install location for the macOS packages.

In order to guarantee that the environment file is in the expected location, set the swiftly
environment variables to default to those location on both macOS and Linux.