### PR TITLE
Fix typos in Static Linux SDK Signature URLs

### DIFF
--- a/_data/builds/swift-6_1-branch/static_sdk.yml
+++ b/_data/builds/swift-6_1-branch/static_sdk.yml
@@ -1,17 +1,17 @@
 - date: 2025-03-25 10:10:00-06:00
   dir: swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-25-a
   download: swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-25-a_static-linux-0.0.1.artifactbundle.tar.gz
-  download_signature: swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-25-a-a_static-linux-0.0.1.artifactbundle.tar.gz.sig
+  download_signature: swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-25-a_static-linux-0.0.1.artifactbundle.tar.gz.sig
   checksum: 2b73c30ec402f443857e6cd2ac06b8525f186e889a7a727af05601629148fe6a
 - date: 2025-03-20 10:10:00-06:00
   dir: swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-20-a
   download: swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-20-a_static-linux-0.0.1.artifactbundle.tar.gz
-  download_signature: swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-20-a-a_static-linux-0.0.1.artifactbundle.tar.gz.sig
+  download_signature: swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-20-a_static-linux-0.0.1.artifactbundle.tar.gz.sig
   checksum: 66a67cd8dc4c01a79c9d2b5965c005f61aa4727c2e4e6170f678bfc0963b228a
 - date: 2025-03-12 10:10:00-06:00
   dir: swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-12-a
   download: swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-12-a_static-linux-0.0.1.artifactbundle.tar.gz
-  download_signature: swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-12-a-a_static-linux-0.0.1.artifactbundle.tar.gz.sig
+  download_signature: swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-12-a_static-linux-0.0.1.artifactbundle.tar.gz.sig
   checksum: c701d3f5bb69464fd443f20c4748cab068c9c6d8f6995f1ba5be70022778d21f
 - date: 2025-01-31 10:10:00-06:00
   dir: swift-6.1-DEVELOPMENT-SNAPSHOT-2025-01-31-a


### PR DESCRIPTION
### Motivation:

As I commented [here](https://github.com/swiftlang/swift-org-website/commit/018ca4354ef294a4d6fd74418f1cb7b97908b7b9#r153827504), a signature file of Static Linux SDK for Swift 6.1 has not available for download lately.

Download page: https://www.swift.org/install/macos/

The reason is that those URLs are wrong.

```console
$ curl https://download.swift.org/swift-6.1-branch/static-sdk/swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-25-a/swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-25-a-a_static-linux-0.0.1.artifactbundle.tar.gz.sig
<?xml version="1.0" encoding="UTF-8" standalone="no"?><Error><Code>404</Code><Message>No message</Message><RequestId>d277fed7-878a-4468-8301-81b07128bbb5</RequestId></Error>
$ curl https://download.swift.org/swift-6.1-branch/static-sdk/swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-25-a/swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-25-a_static-linux-0.0.1.artifactbundle.tar.gz.sig
-----BEGIN PGP SIGNATURE-----

iQIzBAABCAAdFiEE6BPIkoIKb6E3VbJo8WffGs+c4GkFAmfkKAcACgkQ8WffGs+c
4GnqAQ//YGtDktfJLevjmSNP9Df81yde/kyIr+b3xETGrCFqguzU3fxrDDet8gCF
y8X7sTiYAKARP3RKzhBxaCUVtP4uBJi0i1VYaBUZYU32a+7TMZlqWDCuXrvYoygY
eNeuxgwX+va5XX5Ap+kTh1OttgeEGkzZ+v9+UPJ3m5rB2ZnYt+JKYgohBA3wrzLa
e3kLPZJ0F3rkvW7nMSsZ/xRaJVqsBD6OJqS9xbY/F77KlgGQ7gKcy7XGHNnJkddz
LVeq+JtliHQW1vnXZeVQbnl9fIJNtx2s0fKsluLy2DCvJCvCoZervraxFJa3DDty
xAucehDg7/eBU9SuygRuiSlj0lWXst8STQL7EW6Fj+OHAmT9mKwfxK0Twwc0U5rt
GbKBD+wrfU21MigJbbxrM/XaUXPbYAJokj0sf0U/3q3uNz5385jNLOdjcDAgTg2X
2keAYzcKf6WlKnwSFxyEPIe5PCqNRTVaAApnqn47BQJYdEPBQX8rYbgYg6P9clQ4
luiBjVIcdJ530vVA8LLEuq8IqpfgV+tq/OINsmj8VcJEI9eHy9thH4//C3qodrW4
Tb5w0kOVQp+DwUIjW6o1BPw4GsPW6vByurc/b7SXKlXh/R5yXpxpBRScqLXmafMd
qJU/d+ZK50Bn4ZNfGjUp9U8x4IlQLXJlk+STbrqXas6n8CKaoQg=
=3LA5
-----END PGP SIGNATURE-----
```

### Modifications:

I fixed typos in the Static Linux SDK Signature URLs.

### Result:

At least the latest signature file is now available for download.