### PR TITLE
#941 - Fix macOS and Linux pages mobile resize

### DIFF
--- a/assets/stylesheets/elements/_grid.scss
+++ b/assets/stylesheets/elements/_grid.scss
@@ -9,10 +9,12 @@
   background-color: var(--color-fill-secondary);
   border: 1px solid var(--color-fill-tertiary);
   border-radius: var(--border-radius);
+  box-sizing: border-box;
 
   padding: 1rem;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 
   @media (prefers-contrast: more) {
     background-color: transparent;


### PR DESCRIPTION
### Motivation:

Issue: https://github.com/swiftlang/swift-org-website/issues/941

### Modifications:

Changed box overflow

### Result:

<img width="1084" alt="Screenshot 2025-03-28 at 2 21 00 PM" src="https://github.com/user-attachments/assets/ede6803e-2f3a-4cbb-80d9-025b3ffb2346" />

<img width="554" alt="Screenshot 2025-03-28 at 2 20 53 PM" src="https://github.com/user-attachments/assets/70f5dfda-8bba-4dd2-a1dc-e1081aa3514e" />
