### PR TITLE
[API] Add support for Debian 12 and Fedora 39 for 6.1 and main branch

### DIFF
--- a/api/v1/install/dev/6.1/debian12.json
+++ b/api/v1/install/dev/6.1/debian12.json
@@ -1,0 +1,6 @@
+---
+layout: none
+---
+{ "x86_64": {{ site.data.builds.swift-6_1-branch.debian12 | jsonify }},
+  "aarch64": {{ site.data.builds.swift-6_1-branch.debian12-aarch64 | jsonify }}
+}

--- a/api/v1/install/dev/6.1/fedora39.json
+++ b/api/v1/install/dev/6.1/fedora39.json
@@ -1,0 +1,6 @@
+---
+layout: none
+---
+{ "x86_64": {{ site.data.builds.swift-6_1-branch.fedora39 | jsonify }},
+  "aarch64": {{ site.data.builds.swift-6_1-branch.fedora39-aarch64 | jsonify }}
+}

--- a/api/v1/install/dev/main/debian12.json
+++ b/api/v1/install/dev/main/debian12.json
@@ -1,0 +1,6 @@
+---
+layout: none
+---
+{ "x86_64": {{ site.data.builds.development.debian12 | jsonify }},
+  "aarch64": {{ site.data.builds.development.debian12-aarch64 | jsonify }}
+}

--- a/api/v1/install/dev/main/fedora39.json
+++ b/api/v1/install/dev/main/fedora39.json
@@ -1,0 +1,6 @@
+---
+layout: none
+---
+{ "x86_64": {{ site.data.builds.development.fedora39 | jsonify }},
+  "aarch64": {{ site.data.builds.development.fedora39-aarch64 | jsonify }}
+}


### PR DESCRIPTION
Added support for Debian 12 and Fedora 39 to swift.org API for 6.1 and main branch

### Motivation:

This change allows running `swiftly install main-snapshot` and `swift install 6.1-snapshot` on Debian 12 and Fedora 39. This was possible in previous versions of swiftly.

### Modifications:

I added support for Debian 12 and Fedora 39 to swift.org API for 6.1 and main branch.

The referenced data already exists.

- `site.data.builds.swift-6_1-branch.debian12`: https://github.com/swiftlang/swift-org-website/blob/main/_data/builds/swift-6_1-branch/debian12.yml
- `site.data.builds.swift-6_1-branch.debian12-aarch64`: https://github.com/swiftlang/swift-org-website/blob/main/_data/builds/swift-6_1-branch/debian12-aarch64.yml
- `site.data.builds.swift-6_1-branch.fedora39`: https://github.com/swiftlang/swift-org-website/blob/main/_data/builds/swift-6_1-branch/fedora39.yml
- `site.data.builds.swift-6_1-branch.fedora39-aarch64`: https://github.com/swiftlang/swift-org-website/blob/main/_data/builds/swift-6_1-branch/fedora39-aarch64.yml
- `site.data.builds.development.debian12`: https://github.com/swiftlang/swift-org-website/blob/main/_data/builds/development/debian12.yml
- `site.data.builds.development.debian12-aarch64`: https://github.com/swiftlang/swift-org-website/blob/main/_data/builds/development/debian12-aarch64.yml
- `site.data.builds.development.fedora39`: https://github.com/swiftlang/swift-org-website/blob/main/_data/builds/development/fedora39.yml
- `site.data.builds.development.fedora39-aarch64`: https://github.com/swiftlang/swift-org-website/blob/main/_data/builds/development/fedora39-aarch64.yml

### Result:

The following endpoints will be available and return a list of snapshots.

- https://www.swift.org/api/v1/install/dev/6.1/debian12.json
- https://www.swift.org/api/v1/install/dev/main/debian12.json
- https://www.swift.org/api/v1/install/dev/6.1/fedora39.json
- https://www.swift.org/api/v1/install/dev/main/fedora39.json