### PR TITLE
[API] Add support for Windows arm64 for 6.1 and main branch

### DIFF
--- a/api/v1/install/dev/6.1/windows10.json
+++ b/api/v1/install/dev/6.1/windows10.json
@@ -1,4 +1,6 @@
 ---
 layout: none
 ---
-{ "x86_64": {{ site.data.builds.swift-6_1-branch.windows10 | jsonify }}}
+{ "x86_64": {{ site.data.builds.swift-6_1-branch.windows10 | jsonify }},
+  "arm64": {{ site.data.builds.swift-6_1-branch.windows10-arm64 | jsonify }}
+}

--- a/api/v1/install/dev/main/windows10.json
+++ b/api/v1/install/dev/main/windows10.json
@@ -1,4 +1,6 @@
 ---
 layout: none
 ---
-{ "x86_64": {{ site.data.builds.development.windows10 | jsonify }}}
+{ "x86_64": {{ site.data.builds.development.windows10 | jsonify }},
+  "arm64": {{ site.data.builds.development.windows10-arm64 | jsonify }}
+}


### PR DESCRIPTION
Added support for Windows arm64 to swift.org API for 6.1 and main branch

### Motivation:

### Modifications:

I added support for Windows arm64 to swift.org API for 6.1 and main branch.

The referenced data already exists.

- `site.data.builds.swift-6_1-branch.windows10-arm64`: https://github.com/swiftlang/swift-org-website/blob/main/_data/builds/swift-6_1-branch/windows10-arm64.yml
- `site.data.builds.development.windows10-arm64`: https://github.com/swiftlang/swift-org-website/blob/main/_data/builds/development/windows10-arm64.yml

### Result:

The `arm64` fields will be added to the following endpoints.

- https://www.swift.org/api/v1/install/dev/6.1/windows10.json
- https://www.swift.org/api/v1/install/dev/main/windows10.json