### PR TITLE
Replace deprecated `docker-compose` with `docker compose` in the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ open "http://localhost:4000"
 First build the site with Docker Compose:
 
 ```bash
-docker-compose run build
+docker compose run build
 ```
 
 Then you can run the site:
 
 ```bash
-docker-compose up website
+docker compose up website
 ```
 
 The website will be available on `http://localhost:4000`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,9 +9,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # usage:
-# docker-compose run build
+# docker compose run build
 #
-# docker-compose up website
+# docker compose up website
 #
 
 services:


### PR DESCRIPTION
Since Compose V2, `docker-compose` has been deprecated, and instead, `docker compose` has been recommended.

https://docs.docker.com/compose/releases/migrate/#docker-compose-vs-docker-compose