### PR TITLE
Fix linux install command for zsh shell.

### DIFF
--- a/_includes/install/_linux_platforms_tabs.md
+++ b/_includes/install/_linux_platforms_tabs.md
@@ -6,8 +6,8 @@
     The Swiftly installer manages Swift and its dependencies. It supports switching between different versions and downloading updates.
   </p>
   <h4>Run this in a terminal:</h4>
-  <div class="language-plaintext highlighter-rouge"><div class="highlight"><button>Copy</button><pre class="highlight"><code>curl -O https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz &amp;&amp; \
-tar zxf swiftly-$(uname -m).tar.gz &amp;&amp; \
+  <div class="language-plaintext highlighter-rouge"><div class="highlight"><button>Copy</button><pre class="highlight"><code>curl -O "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz" &amp;&amp; \
+tar zxf "swiftly-$(uname -m).tar.gz" &amp;&amp; \
 ./swiftly init --quiet-shell-followup &amp;&amp; \
 . ~/.local/share/swiftly/env.sh &amp;&amp; \
 hash -r


### PR DESCRIPTION
### Motivation:

The current shell script does not work for zsh resulting in the following error.

```
zsh: parse error near `)'. 
```

### Modifications:

Adding quotes around the file name fixes the command for bash and zsh. Tested locally.


### Result:

Install command works for zsh and bash.
