### PR TITLE
correct address sanitizer reference in server guide 

### DIFF
--- a/documentation/server/guides/memory-leaks-and-usage.md
+++ b/documentation/server/guides/memory-leaks-and-usage.md
@@ -41,7 +41,7 @@ To enable Zombie Objects:
 4. Choose the **Diagnostics** tab.
 5. Under **Memory Management**, check the box next to **Enable Zombie Objects**.
     
-*On Linux*: Swift has built-in LeakSanitizer support that can be enabled using the `-sanitize=leak` compiler flag.
+*On Linux*: Swift has built-in LeakSanitizer support that can be enabled using the Address Sanitizer. For more information, read the section [Debugging Leaks with LeakSanitizer](#debugging-leaks-with-leaksanitizer).
 
 ## Troubleshooting
 


### PR DESCRIPTION
remove incorrect suggestion and direct to section that details the process using swift build and ASAN_OPTIONS set

### Motivation:

Thread on the Open Source slack highlighted some confusion around the existing documentation. The correct documentation is there, but wasn't referenced.

### Modifications:

Removes the incorrect suggestion (`-sanitize=leaks`) and replaces it with a reference to the correct documentation.

### Result:

For more information... link to the correct section.

(resolves rdar://148594440)
