### PR TITLE
Updated Chinese translation URL.

### DIFF
--- a/documentation/tspl/index.md
+++ b/documentation/tspl/index.md
@@ -31,7 +31,7 @@ We encourage you to participate in translating _The Swift Programming Language_ 
 Get involved with an existing translation project, or start a new one.
 
 <div class="links links-external links-list-nostyle" markdown="1">
-- [Read Chinese translation](https://swiftgg.gitbook.io/swift){:target="_blank"}
+- [Read Chinese translation](https://doc.swiftgg.team){:target="_blank"}
 - [Read Japanese translation](https://www.swiftlangjp.com){:target="_blank"}
 - [Read Korean translation](https://bbiguduk.gitbook.io/swift){:target="_blank"}
 - [Read Ukrainian translation](https://book.swift.org.ua){:target="_blank"}


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_Update Chinese translation website URL in documentation_
-->

### Motivation:

The Chinese translation website URL needs to be updated to reflect the current location of the Swift programming language documentation in Chinese. This change ensures that Chinese-speaking developers can access the most up-to-date translation resources.

### Modifications:

- Updated the Chinese translation website URL from the old link to `https://doc.swiftgg.team`

### Result:

After this change, Chinese-speaking developers will be directed to the correct and current URL for accessing the Swift programming language documentation in Chinese. This improves the accessibility of Swift documentation for the Chinese developer community.