### PR TITLE
Add OpenAPI checksum field to Platform for static SDK objects

### DIFF
--- a/openapi/swiftorg.yaml
+++ b/openapi/swiftorg.yaml
@@ -284,6 +284,9 @@ components:
           items:
             $ref: '#/components/schemas/Architecture'
           description: List of supported architectures.
+        checksum:
+          type: string
+          description: SHA-256 Checksum of the static SDK, if this platform is the static SDK.
       required:
         - name
         - platform


### PR DESCRIPTION
This field is present in platform objects representing 