### PR TITLE
[SSWG] Remove affiliation for Simon and use AWS for Josh and Seb

### DIFF
--- a/_data/server-workgroup/members.yml
+++ b/_data/server-workgroup/members.yml
@@ -16,7 +16,7 @@
 
 - name: Josh Elkins
   github: jbelkins
-  affiliation: Amazon
+  affiliation: AWS
 
 - name: Adam Fowler
   github: adam-fowler
@@ -36,7 +36,7 @@
 
 - name: Simon Pilkington
   github: tachyonics
-  affiliation: Atlassian
+  affiliation: 
 
 - name: Gwynne Raskind
   github: gwynne
@@ -48,4 +48,4 @@
 
 - name: Sebastien Stormacq
   github: sebsto
-  affiliation: Amazon
+  affiliation: AWS


### PR DESCRIPTION
### Motivation:

- remove affiliation for Simon 
- change Josh and Seb's affiliation from Amazon to AWS

### Modifications:

Modified the `_data/server-workgroup/members.yml` 

### Result:

This page at https://www.swift.org/sswg/ is updated
