### PR TITLE
Fix swiftly shell scripts for case where SWIFTLY_HOME_DIR is set

### DIFF
--- a/_includes/install/_linux_platforms_tabs.md
+++ b/_includes/install/_linux_platforms_tabs.md
@@ -9,7 +9,7 @@
   <div class="language-plaintext highlighter-rouge"><div class="highlight"><button>Copy</button><pre class="highlight"><code>curl -O "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz" &amp;&amp; \
 tar zxf "swiftly-$(uname -m).tar.gz" &amp;&amp; \
 ./swiftly init --quiet-shell-followup &amp;&amp; \
-. ~/.local/share/swiftly/env.sh &amp;&amp; \
+. ${SWIFTLY_HOME_DIR:-~/.local/share/swiftly}/env.sh &amp;&amp; \
 hash -r
 </code></pre></div></div>
   <h4>License: <a href="https://raw.githubusercontent.com/swiftlang/swiftly/refs/heads/main/LICENSE.txt">Apache-2.0</a> | PGP: <a href="https://download.swift.org/swiftly/linux/swiftly-0.4.0-dev-x86_64.tar.gz.sig">Signature</a></h4>

--- a/install/macos/index.md
+++ b/install/macos/index.md
@@ -16,7 +16,7 @@ title: Install Swift
   <div class="language-plaintext highlighter-rouge"><div class="highlight"><button>Copy</button><pre class="highlight"><code>curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg &amp;&amp; \
 installer -pkg swiftly.pkg -target CurrentUserHomeDirectory &amp;&amp; \
 ~/.swiftly/bin/swiftly init --quiet-shell-followup &amp;&amp; \
-. ~/.swiftly/env.sh &amp;&amp; \
+. ${SWIFTLY_HOME_DIR:-~/.swiftly}/env.sh &amp;&amp; \
 hash -r
 </code></pre></div></div>
   <h4>License: <a href="https://raw.githubusercontent.com/swiftlang/swiftly/refs/heads/main/LICENSE.txt">Apache-2.0</a></h4>


### PR DESCRIPTION
When SWIFTLY_HOME_DIR is set then swiftly will put the environment script in
that location. Fix the website scripts to accommodate the case where the environment
variable is already set.