### PR TITLE
Updated Community Showcase packages for May

### DIFF
--- a/_data/packages/packages.yml
+++ b/_data/packages/packages.yml
@@ -9,55 +9,55 @@ categories:
       organised via [this thread in the Swift Forums](https://forums.swift.org/t/68168)
       and curated by the [Swift Website Workgroup](https://www.swift.org/website-workgroup/).
     packages:
-      - name: FileMonitor
-        description: FileMonitor provides a unified API to detect file changes in a directory
-          on Linux and macOS. It detects file creations, modifications, and deletions
-          and then propagates events through a delegate function.
-        owner: aus der Technik - Simon & Simon GbR
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (macOS) and Linux
-        license: MIT
-        url: https://swiftpackageindex.com/aus-der-Technik/FileMonitor
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/125){:target='_blank'}.
-      - name: Versionator
-        description: A plugin to gathers version information and embeds it into a package/executable,
-          allowing retrieval at runtime. Generates `Version.swift`, `Info.plist`, and
-          a header file.
-        owner: Elegant Chaos
+      - name: Anodize
+        description: Adds type safety to Metal shaders, enabling Swift to interact with
+          Metal kernels without managing binding indices. Enhances code safety and simplifies
+          GPU kernel integration.
+        owner: Audulus LLC
         swift_compatibility: 6.0+
         platform_compatibility:
           - Apple
         platform_compatibility_tooltip: Apple (macOS)
         license: MIT
-        url: https://swiftpackageindex.com/elegantchaos/Versionator
-        note: Discussed on [Episode 49 of Swift Package Indexing](https://share.transistor.fm/s/c3ea4e1a){:target='_blank'}.
-      - name: Numerix
-        description: Provides Complex, Vector, Matrix, and ShapedArray structures for
-          linear algebra and numerical computations using the Accelerate framework for
-          high-performance calculations.
-        owner: Gavin Wiggins
-        swift_compatibility: 6.0+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-        license: MIT
-        url: https://swiftpackageindex.com/wigging/numerix
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/119){:target='_blank'}.
-      - name: swift-zip-archive
-        description: A library for reading and editing zip archives. Supports reading
-          and writing standard or password protected zip files from disk and memory buffers.
-        owner: Adam Fowler
+        url: https://swiftpackageindex.com/audulus/Anodize
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/123){:target='_blank'}.
+      - name: Noora
+        description: Enhances terminal aesthetics for Swift CLIs with a customizable design
+          system, improving consistency and readability in command-line interfaces.
+        owner: Tuist
         swift_compatibility: 6.0+
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS) and Linux
+        platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
+        license: MIT
+        url: https://swiftpackageindex.com/tuist/Noora
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/120){:target='_blank'}.
+      - name: swift-aws-lambda-runtime
+        description: Facilitates building serverless functions in Swift for AWS Lambda,
+          offering features like JSON handling, response streaming, and background tasks,
+          while emphasizing performance, safety, and developer control.
+        owner: Swift on Server
+        swift_compatibility: 5.9+
+        platform_compatibility:
+          - Apple
+          - Linux
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: Apache 2.0
-        url: https://swiftpackageindex.com/adam-fowler/swift-zip-archive
-        note: Discussed on [Episode 53 of Swift Package Indexing](https://share.transistor.fm/s/56a29e9f){:target='_blank'}.
+        url: https://swiftpackageindex.com/swift-server/swift-aws-lambda-runtime
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/127){:target='_blank'}.
+      - name: swift-package-registry-service
+        description: An implementation of the Swift Package Registry Service which proxies
+          the Github API.
+        owner: CrowdStrike
+        swift_compatibility: 6.0+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (macOS, visionOS)
+        license: MIT
+        url: https://swiftpackageindex.com/CrowdStrike/swift-package-registry-service
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/128){:target='_blank'}.
   - name: Packages with Macros
     slug: macros
     brief: New in Swift 5.9, Swift packages can include macro targets. Browse a selection

--- a/_data/packages/showcase-history.yml
+++ b/_data/packages/showcase-history.yml
@@ -1,6 +1,115 @@
 years:
   - year: 2025
     months:
+      - month: April
+        slug: april
+        packages:
+          - name: grpc-swift
+            description: gRPC is a high performance, open source universal RPC framework.
+              This package is a Swift language implementation of gRPC.
+            owner: grpc
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/grpc/grpc-swift
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/127){:target='_blank'}.
+          - name: Spices
+            description: Spices facilitates creating in-app debug menus by generating native
+              UI from Swift. It uses the `@Spice` property wrapper and `SpiceStore` protocol
+              to store settings and manage environment configurations.
+            owner: Shape ApS
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS)
+            license: MIT
+            url: https://swiftpackageindex.com/shapehq/spices
+            note: Discussed on [Episode 54 of Swift Package Indexing](https://share.transistor.fm/s/a176e767){:target='_blank'}.
+          - name: swift-otel
+            description: Client for server-side Swift, implementing OpenTelemetry for tracing
+              and metrics. Demonstrates usage with examples like a counter service and HTTP
+              server for distributed tracing.
+            owner: Swift OTel
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/swift-otel/swift-otel
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/127){:target='_blank'}.
+          - name: sharing-grdb
+            description: SharingGRDB offers a fast, lightweight alternative to SwiftData,
+              utilizing SQLite for data management. It supports SwiftUI and UIKit, providing
+              property wrappers for data fetching and observation.
+            owner: Point-Free
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/pointfreeco/sharing-grdb
+            note: Discussed on [Episode 54 of Swift Package Indexing](https://share.transistor.fm/s/a176e767){:target='_blank'}.
+      - month: March
+        slug: march
+        packages:
+          - name: FileMonitor
+            description: FileMonitor provides a unified API to detect file changes in a
+              directory on Linux and macOS. It detects file creations, modifications, and
+              deletions and then propagates events through a delegate function.
+            owner: aus der Technik - Simon & Simon GbR
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (macOS) and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/aus-der-Technik/FileMonitor
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/125){:target='_blank'}.
+          - name: Versionator
+            description: A plugin to gathers version information and embeds it into a package/executable,
+              allowing retrieval at runtime. Generates `Version.swift`, `Info.plist`, and
+              a header file.
+            owner: Elegant Chaos
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (macOS)
+            license: MIT
+            url: https://swiftpackageindex.com/elegantchaos/Versionator
+            note: Discussed on [Episode 49 of Swift Package Indexing](https://share.transistor.fm/s/c3ea4e1a){:target='_blank'}.
+          - name: Numerix
+            description: Provides Complex, Vector, Matrix, and ShapedArray structures for
+              linear algebra and numerical computations using the Accelerate framework for
+              high-performance calculations.
+            owner: Gavin Wiggins
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/wigging/numerix
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/119){:target='_blank'}.
+          - name: swift-zip-archive
+            description: A library for reading and editing zip archives. Supports reading
+              and writing standard or password protected zip files from disk and memory
+              buffers.
+            owner: Adam Fowler
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS) and Linux
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/adam-fowler/swift-zip-archive
+            note: Discussed on [Episode 53 of Swift Package Indexing](https://share.transistor.fm/s/56a29e9f){:target='_blank'}.
       - month: February
         slug: february
         packages:


### PR DESCRIPTION
This update contains the [Community Showcase packages](https://www.swift.org/packages/showcase.html) for May.

Packages in the Community Showcase are nominated by the community in [this thread on the Swift forums](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168) and voted on by the [SWWG](https://www.swift.org/website-workgroup/).

![Screenshot 2025-05-13 at 13 44 50@2x](https://github.com/user-attachments/assets/324080bf-212c-4612-a23d-ebe32b85bd65)
