### PR TITLE
Fix mobile code box and link callout

### DIFF
--- a/assets/stylesheets/new-stylesheets/pages/_install.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_install.scss
@@ -230,6 +230,11 @@
         word-break: break-word;
       }
     }
+
+    .content-body {
+      flex-grow: 1;
+      width: 100%;
+    }
   }
 
   .content {
@@ -281,10 +286,6 @@
         display: flex;
         flex-direction: column;
         min-height: 200px;
-
-        .content-body {
-          flex-grow: 1;
-        }
       }
     }
   }

--- a/assets/stylesheets/new-stylesheets/pages/_install.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_install.scss
@@ -24,6 +24,7 @@
       margin-top: 60px;
       position: relative;
       z-index: 10;
+      line-height: 1.2em;
     }
 
     h3 {
@@ -48,6 +49,10 @@
           @include link-with-right-arrow;
           margin-top: 10px;
           display: flex;
+
+          &.centered {
+            justify-content: center;
+          }
 
           i {
             filter: var(--site-content-link-with-right-arrow-icon-filter);
@@ -208,7 +213,7 @@
     h2 {
       color: var(--site-code-box-text) !important;
       font-size: 22px;
-      margin: 0 !important;
+      margin: 0 0 10px 0 !important;
     }
 
     pre {

--- a/install/linux/index.md
+++ b/install/linux/index.md
@@ -21,7 +21,7 @@ title: Install Swift - Linux
   <h2>Looking for alternate installation options?</h2>
     <div>
       <p class="content-copy">
-        <a class="content-link" href="/install/linux/amazonlinux/2">Check them out <i></i></a>
+        <a class="content-link centered" href="/install/linux/amazonlinux/2">Check them out <i></i></a>
       </p>
     </div>
   </div>

--- a/scripts/copy-vendor.sh
+++ b/scripts/copy-vendor.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift.org project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 mkdir -p assets/js/vendor
 

--- a/scripts/prettify.sh
+++ b/scripts/prettify.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2025 Apple Inc. and the Swift.org project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift.org project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 prettier --write \
   "assets/{javascripts/new-javascripts,stylesheets/new-stylesheets}/**/*.{js,scss}" \


### PR DESCRIPTION
### Motivation:

There are a couple of style issues:

<img width="417" alt="Screenshot 2025-05-27 at 10 59 24 PM" src="https://github.com/user-attachments/assets/ae2d0531-73f3-4b6a-9d7c-79646e08263d" />

<img width="1269" alt="Screenshot 2025-05-27 at 10 47 51 PM" src="https://github.com/user-attachments/assets/8d740e67-663d-4b7f-8026-c89e9d83dcac" />

### Result:

<img width="417" alt="Screenshot 2025-05-27 at 10 59 24 PM" src="https://github.com/user-attachments/assets/fd12b375-6bb0-4b60-a46e-7c0e95a9fc4a" />

<img width="1146" alt="Screenshot 2025-05-27 at 10 51 54 PM" src="https://github.com/user-attachments/assets/0dbf3317-d6d8-4d4b-a9ba-4f6d5bea0ee3" />



