### PR TITLE
Update links and tweak text on Embedded use case page

### DIFF
--- a/_data/new-data/get-started/embedded/card-grid.yml
+++ b/_data/new-data/get-started/embedded/card-grid.yml
@@ -6,12 +6,15 @@ tertiary_cards:
   - name: "Integrate with Raspberry Pi Pico SDK"
     text: "Take advantage of seamless interoperatibility and use existing APIs from the Pico SDK directly from your Swift code."
     link_text: Open guide
-    link: https://swiftpackageindex.com/apple/swift-embedded-examples/main/documentation/embeddedswift/integratewithpico
+    link: https://swiftpackageindex.com/apple/swift-embedded-examples/main/documentation/embeddedswift/picoguide
   - name: "Go baremetal on STM32 chips"
     text: "For maximum control, you can run completely baremetal and use Swift MMIO to operate hardware devices."
     link_text: Open guide
     link: https://swiftpackageindex.com/apple/swift-embedded-examples/main/documentation/embeddedswift/stm32baremetalguide
-paragraph:
+text:
   Embedded Swift is not limited to specific hardware devices or platforms. It's versatile, it can be integrated with
-  existing SDKs and build systems, and it can also be used for pure baremetal development. Most commonly used ARM
+  existing SDKs and build systems, and it can also be used for pure baremetal development. Most common ARM
   and RISC-V chips can be targeted by the Swift toolchain.
+link:
+  url: https://swiftpackageindex.com/apple/swift-embedded-examples/main/documentation/embeddedswift/integratingwithplatforms
+  text: Learn more about integration with other platforms and build systems

--- a/_data/new-data/get-started/embedded/code-image-column.yml
+++ b/_data/new-data/get-started/embedded/code-image-column.yml
@@ -24,7 +24,7 @@ code: |-
       }
     } 
   }
-body: In just 788 bytes, Embedded Swift powers Conway’s Game of Life on the Playdate handheld—melding high‑level abstractions with low‑level bit‑twiddling for real‑time animation.
+body: In just 788 bytes of resulting compiled code, Embedded Swift powers Conway’s Game of Life on the Playdate handheld—melding high‑level abstractions with low‑level bit‑twiddling for real‑time animation.
 link:
   url: https://www.swift.org/blog/byte-sized-swift-tiny-games-playdate/
   text: Learn more

--- a/_data/new-data/get-started/embedded/hero.yml
+++ b/_data/new-data/get-started/embedded/hero.yml
@@ -1,7 +1,7 @@
 headline: Create embedded software with Swift
 body: Develop efficient, reliable firmware for devices like microcontrollers
 link:
-  url: /getting-started/embedded-swift
+  url: https://swiftpackageindex.com/apple/swift-embedded-examples/main/documentation/embeddedswift/waystogetstarted
   text: Get Started
 boxes:
   - title: Safe

--- a/_data/new-data/get-started/embedded/link-columns.yml
+++ b/_data/new-data/get-started/embedded/link-columns.yml
@@ -2,8 +2,10 @@ headline: Learn more
 columns:
   - headline: Documentation
     links:
-      - text: Build an embedded app for a microcontroller
-        url: '/getting-started/embedded-swift/'
+      - text: Embedded Swift documentation
+        url: 'https://swiftpackageindex.com/apple/swift-embedded-examples/main/documentation/embeddedswift'
+      - text: Getting started with Embedded Swift
+        url: 'https://swiftpackageindex.com/apple/swift-embedded-examples/main/documentation/embeddedswift/waystogetstarted'
       - text: Embedded Swift vision document
         url: 'https://github.com/swiftlang/swift-evolution/blob/main/visions/embedded-swift.md'
       - text: Embedded Swift example projects

--- a/_data/new-data/get-started/embedded/primary-content.yml
+++ b/_data/new-data/get-started/embedded/primary-content.yml
@@ -20,7 +20,7 @@ secondary_cards:
     logo: /assets/images/get-started/interactive-ui-examples@2x.png
     text: Build projects using the popular embedded graphics library LVGL on an STM32 board for rich UI and touch input.
     link_text: Learn more
-    link: https://github.com/apple/swift-embedded-examples/pull/104
+    link: https://github.com/apple/swift-embedded-examples/tree/main/stm32-lvgl
 
   - name: PlaydateKit
     logo: /assets/images/get-started/playdate-kit@2x.png

--- a/_includes/new-includes/components/card-grid.html
+++ b/_includes/new-includes/components/card-grid.html
@@ -50,7 +50,11 @@
       </li>
       {% endfor %}
     </ul>
-    {% endif %} {% if include.content.link %}
+    {% endif %}
+    {% if include.content.text %}
+    <p>{{ include.content.text }}</p>
+    {% endif %}
+    {% if include.content.link %}
     <a href="{{ include.content.link.url }}"
       >{{ include.content.link.text }} <i></i
     ></a>

--- a/get-started/embedded/index.md
+++ b/get-started/embedded/index.md
@@ -12,7 +12,7 @@ title: Embedded
 <!-- Runs on many embedded platforms -->
 
 <style>
-.hero-card { aspect-ratio: auto; width: auto; }
+.card-grid p { margin-bottom: 20px; }
 </style>
 {% include new-includes/components/card-grid.html content = site.data.new-data.get-started.embedded.card-grid %}
 


### PR DESCRIPTION
Fix a bunch of links to Embedded Swift docs:

- Point the main "Get Started" button to the getting started doc page.
- Link the pico guide to the correct new link.
- Put in the "learn more about platforms" link.
- Add more doc links in the bottom "Resources" section.
- Fix the LVGL demo link to the repo instead of the PR.

Also:
- Change "In just 788 bytes, Embedded Swift powers Conway’s Game of Life" into "In just 788 bytes of resulting compiled code..." because IMHO it's not clear that that the 788 bytes refer to the compiled result (it could be interpreted as source code having 788 bytes).
