### PR TITLE
Add Fish for Swiftly install

### DIFF
--- a/_data/new-data/install/linux/releases.yml
+++ b/_data/new-data/install/linux/releases.yml
@@ -6,11 +6,17 @@ latest-release:
     tabs:
       - label: Bash
         code: |-
-          curl -O "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz" && \
-          tar zxf "swiftly-$(uname -m).tar.gz" && \
+          curl -O https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz && \
+          tar zxf swiftly-$(uname -m).tar.gz && \
           ./swiftly init --quiet-shell-followup && \
-          . ~/.local/share/swiftly/env.sh && \
+          . "${SWIFTLY_HOME_DIR:-~/.local/share/swiftly}/env.sh" && \
           hash -r
+      - label: Fish
+        code: |-
+          curl -O https://download.swift.org/swiftly/linux/swiftly-(uname -m).tar.gz && \
+          tar zxf swiftly-(uname -m).tar.gz && \
+          ./swiftly init --quiet-shell-followup && \
+          set -q SWIFTLY_HOME_DIR && . "$SWIFTLY_HOME_DIR/env.fish" || . ~/.local/share/swiftly/env.fish
     links:
       - href: 'https://raw.githubusercontent.com/swiftlang/swiftly/refs/heads/main/LICENSE.txt'
         copy: 'License: Apache-2.0'

--- a/_data/new-data/install/macos/releases.yml
+++ b/_data/new-data/install/macos/releases.yml
@@ -9,8 +9,14 @@ latest-release:
           curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg && \
           installer -pkg swiftly.pkg -target CurrentUserHomeDirectory && \
           ~/.swiftly/bin/swiftly init --quiet-shell-followup && \
-          . ${SWIFTLY_HOME_DIR:-~/.swiftly}/env.sh && \
+          . "${SWIFTLY_HOME_DIR:-~/.swiftly}/env.sh" && \
           hash -r
+      - label: Fish
+        code: |
+          curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg && \
+          installer -pkg swiftly.pkg -target CurrentUserHomeDirectory && \
+          ~/.swiftly/bin/swiftly init --quiet-shell-followup && \
+          set -q SWIFTLY_HOME_DIR && . "$SWIFTLY_HOME_DIR/env.fish" || . ~/.swiftly/env.fish
     links:
       - href: 'https://raw.githubusercontent.com/swiftlang/swiftly/refs/heads/main/LICENSE.txt'
         copy: 'License: Apache-2.0'

--- a/install/linux/index.md
+++ b/install/linux/index.md
@@ -8,7 +8,7 @@ title: Install Swift - Linux
 <div class="content">
   <div class="release-box section">
     <div class="content">
-      {% include new-includes/components/code-box.html content = site.data.new-data.install.linux.releases.latest-release.swiftly %}
+      {% include new-includes/components/code-box.html with-tabs = true content = site.data.new-data.install.linux.releases.latest-release.swiftly %}
     </div>
   </div>
   <div class="release-box section">

--- a/install/macos/index.md
+++ b/install/macos/index.md
@@ -11,7 +11,7 @@ title: Install Swift - macOS
 <div class="content">
   <div class="release-box section">
     <div class="content">
-      {% include new-includes/components/code-box.html content = site.data.new-data.install.macos.releases.latest-release.swiftly%}
+      {% include new-includes/components/code-box.html with-tabs = true content = site.data.new-data.install.macos.releases.latest-release.swiftly%}
     </div>
   </div>
   <div class="release-box section">


### PR DESCRIPTION
### Motivation:

For Swiftly installation we need to add the Fish command

### Result:

Tab and command are added for Linux and macOS
