### PR TITLE
Add main nav links to footer

### DIFF
--- a/_data/new-data/footer/main-navigation.yml
+++ b/_data/new-data/footer/main-navigation.yml
@@ -1,0 +1,10 @@
+- title: Docs
+  link: /documentation/
+- title: Community
+  link: /community/
+- title: Packages
+  link: /packages/
+- title: Blog
+  link: /blog/
+- title: Install
+  link: /install/

--- a/_includes/new-includes/footer/footer.html
+++ b/_includes/new-includes/footer/footer.html
@@ -1,9 +1,7 @@
 <footer class="global-footer">
   <div class="container">
     <div class="footer-navigation-container">
-      <div class="notes">
-        <a class="logo" href="/" title="Swift.org"> {% include new-includes/header/logo.html %} </a>
-      </div>
+      {% include new-includes/footer/navigations/main.html %}
 
       {% include new-includes/footer/navigations/tools.html %}
 

--- a/_includes/new-includes/footer/navigations/main.html
+++ b/_includes/new-includes/footer/navigations/main.html
@@ -1,0 +1,11 @@
+<nav aria-label="Main">
+    <a class="logo" href="/" title="Swift.org"> {% include new-includes/header/logo.html %} </a>
+
+    <ul>
+        {% for item in site.data.new-data.footer.main-navigation %}
+        <li class="item {% if page.url == item.url %}active{% endif %}">
+            <a href="{{ item.link }}" data-text="{{ item.title }}">{{ item.title }}</a>
+        </li>
+        {% endfor %}
+    </ul>
+</nav>

--- a/assets/stylesheets/new-stylesheets/includes/footer/_base.scss
+++ b/assets/stylesheets/new-stylesheets/includes/footer/_base.scss
@@ -29,27 +29,29 @@ footer.global-footer {
     flex-wrap: wrap;
     margin-bottom: 5em;
 
-    .notes {
-      .logo {
-          display: flex;
-          width: 116px;
+    .logo {
+        display: flex;
+        height: 36px;
+        margin-bottom: 15px;
 
-          svg {
-            flex: 1;
-          }
+        svg {
+          height: 100%;
+        }
 
-          #logotype {
-            fill: #ebecf0;
-          }
-      }
+        #logotype {
+          fill: #ebecf0;
+        }
     }
 
     h3 {
+      height: 36px;
       margin-bottom: 15px;
       color: #FCA76C;
       font-size: 1.17em;
       line-height: 1.2;
       font-weight: bold;
+      display: flex;
+      align-items: center;
     }
 
     nav {

--- a/assets/stylesheets/new-stylesheets/includes/footer/_mobile.scss
+++ b/assets/stylesheets/new-stylesheets/includes/footer/_mobile.scss
@@ -5,8 +5,14 @@
       align-items: center;
       margin-bottom: 3em;
 
-      .notes .logo {
+      .logo {
         margin-bottom: 3em;
+      }
+
+      h3 {
+        height: auto;
+        display: block;
+        align-items: unset;
       }
 
       nav {


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

It's good UX to include the main navigation links in the footer as well. For reference, see [this article on "Doormat Navigation"](https://www.nngroup.com/articles/footers/#toc-doormat-navigation-5).

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Adds the main navigation links to the footer
  - I vertically centered the navigation titles (Tools, Community, Governance) with the Swift logo on desktop to make this look as balanced as possible
  - ❓ I'm wondering if we maybe need a bit more margin between the logo and the links on desktop
- Restructures the code slightly to allow for this — feel free to suggest improvements here!

### Result:

<!-- _[After your change, what will change.]_ -->

|Before (desktop)|After (desktop)|
|---|---|
|![CleanShot 2025-05-29 at 09 36 11](https://github.com/user-attachments/assets/730af049-ee11-496a-ab13-be11f8fc4ef9)|![CleanShot 2025-05-29 at 09 36 24](https://github.com/user-attachments/assets/7ec8f773-05aa-4f6e-8287-51f8e540a1f2)|

|Before (mobile)|After (mobile)|
|---|---|
|![CleanShot 2025-05-29 at 09 36 05](https://github.com/user-attachments/assets/5d464400-ba37-4319-b83b-c7852cb22e01)|![CleanShot 2025-05-29 at 09 35 56](https://github.com/user-attachments/assets/9e83edf3-4024-4ab2-b2fc-809ccc76a81f)|




