### PR TITLE
Update Core Libraries page

### DIFF
--- a/documentation/core-libraries/_foundation.md
+++ b/documentation/core-libraries/_foundation.md
@@ -9,11 +9,8 @@ The Foundation framework defines a base layer of functionality that is required 
 * Provide a level of OS independence, to enhance portability.
 
 
-More information about the Foundation framework in general is available
-[from Apple's documentation](https://developer.apple.com/reference/foundation).  The Swift.org version of Foundation makes use of many
-of the same underlying libraries (e.g. ICU and CoreFoundation) as Apple's
-implementation, but has been built to be completely independent of the
-Objective-C runtime.  Because of this, it is a substantial reimplementation of
-the same API, using pure Swift code layered on top of these common underlying
-libraries.  Much more information about this work is available on our
-[GitHub project page](http://www.github.com/swiftlang/swift-corelibs-foundation).
+Swift 6 unified the implementation of [Foundation](https://developer.apple.com/documentation/foundation/) across all platforms. The modern, portable Swift implementation provides consistency across platforms, it’s more robust, and it’s open source.
+
+If your app is particularly sensitive to binary size, you can import the `FoundationEssentials` library, which provides a more targeted subset of Foundation’s features that omits internationalization and localization data.
+
+Much more information about this work is available on our [GitHub project page](https://github.com/swiftlang/swift-foundation).

--- a/documentation/core-libraries/_foundation.md
+++ b/documentation/core-libraries/_foundation.md
@@ -13,4 +13,4 @@ Swift 6 unifies the implementation of [Foundation](https://developer.apple.com/d
 
 If your app is particularly sensitive to binary size, you can import the `FoundationEssentials` library, which provides a more targeted subset of Foundation’s features that omits internationalization and localization data.
 
-Much more information about this work is available on our [GitHub project page](https://github.com/swiftlang/swift-foundation).
+More information about this work is available on our [GitHub project page](https://github.com/swiftlang/swift-foundation).

--- a/documentation/core-libraries/_foundation.md
+++ b/documentation/core-libraries/_foundation.md
@@ -9,7 +9,7 @@ The Foundation framework defines a base layer of functionality that is required 
 * Provide a level of OS independence, to enhance portability.
 
 
-Swift 6 unified the implementation of [Foundation](https://developer.apple.com/documentation/foundation/) across all platforms. The modern, portable Swift implementation provides consistency across platforms, it’s more robust, and it’s open source.
+Swift 6 unifies the implementation of [Foundation](https://developer.apple.com/documentation/foundation/) across all platforms. Foundation's modern, portable Swift implementation provides consistency across platforms, is more robust, and is open source.
 
 If your app is particularly sensitive to binary size, you can import the `FoundationEssentials` library, which provides a more targeted subset of Foundation’s features that omits internationalization and localization data.
 

--- a/documentation/core-libraries/_foundation.md
+++ b/documentation/core-libraries/_foundation.md
@@ -9,7 +9,7 @@ The Foundation framework defines a base layer of functionality that is required 
 * Provide a level of OS independence, to enhance portability.
 
 
-Swift 6 unifies the implementation of [Foundation](https://developer.apple.com/documentation/foundation/) across all platforms. Foundation's modern, portable Swift implementation provides consistency across platforms, is more robust, and is open source.
+Swift 6 unifies the implementation of key [Foundation](https://developer.apple.com/documentation/foundation/) API across all platforms. Foundation's modern, portable Swift implementation provides consistency across platforms, is more robust, and is open source.
 
 If your app is particularly sensitive to binary size, you can import the `FoundationEssentials` library, which provides a more targeted subset of Foundation’s features that omits internationalization and localization data.
 

--- a/documentation/core-libraries/_swift-testing.md
+++ b/documentation/core-libraries/_swift-testing.md
@@ -1,0 +1,9 @@
+## Swift Testing
+
+Swift Testing is a package with expressive and intuitive APIs that make testing your Swift code a breeze.
+
+It provides detailed output when a test fails using macros like `#expect`. And it scales to large codebases with features like parameterization to easily repeat a test with different arguments.
+
+If you already have tests written using XCTest, you can run them side-by-side with newer tests written using Swift Testing. This helps you migrate tests incrementally, at your own pace.
+
+More information about Swift Testing is available on our [GitHub project page](https://github.com/swiftlang/swift-testing).

--- a/documentation/core-libraries/_xctest.md
+++ b/documentation/core-libraries/_xctest.md
@@ -1,7 +1,11 @@
 ## XCTest
 
-The XCTest library is designed to provide a common framework for writing unit tests in Swift, for Swift packages and applications.
+The XCTest library provides a common framework for writing unit tests in Swift, for Swift packages and applications.
 
-This version of XCTest uses the same API as the XCTest you are familiar with from Xcode. Our goal is to enable your project's tests to run on all Swift platforms without having to rewrite them.
+This version of XCTest uses the same API as the XCTest you may be familiar with from Xcode. Our goal is to enable your project's tests to run on all Swift platforms without having to rewrite them.
+
+While XCTest remains supported, [Swift Testing](https://github.com/swiftlang/swift-testing) is the recommended framework for writing new tests. Swift Testing offers a modern, expressive, and extensible approach to testing in Swift, and represents the direction of future development.
+
+If you already have tests written using XCTest, you can run them side-by-side with newer tests written using Swift Testing.
 
 More information about XCTest on Linux is available on our [GitHub project page](http://www.github.com/swiftlang/swift-corelibs-xctest).

--- a/documentation/core-libraries/index.md
+++ b/documentation/core-libraries/index.md
@@ -25,14 +25,13 @@ have a goal of providing stable and useful features in the following key areas:
 
 These libraries are part of our ongoing work to extend the cross-platform capabilities of Swift.  We chose to make them part of our open source release so that we can work on them together with the community.
 
-Writing code that provides all of this functionality from scratch would be an enormous undertaking. Therefore, we've decided to bootstrap this project by taking advantage of great work that has already been done in these areas. Specifically, we will reuse the API and as much implementation as is possible from three existing libraries: `Foundation`, `libdispatch`, and `XCTest`.
+Writing code that provides all of this functionality from scratch would be an enormous undertaking. Therefore, we've decided to bootstrap this project by taking advantage of great work that has already been done in these areas. Specifically, we will reuse the API and as much implementation as is possible from three existing libraries: `Foundation`, `libdispatch`, and `XCTest`. In addition to these there is `Swift Testing`, a new testing library designed from the ground up for Swift.
 
 * * *
 
 {% include_relative _foundation.md %}
 {% include_relative _libdispatch.md %}
+{% include_relative _swift-testing.md %}
 {% include_relative _xctest.md %}
 
 * * *
-
-As stated above, this project is in its early days. We look forward to working together with the community to create a great set of libraries that enable Swift to produce powerful software across platforms.


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

Update the Swift Core Libraries page for Swift Testing and new Swift Foundation.

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->
The Core Libraries page was missing Swift Testing, and the Foundation section wasn't updated for Swift 6's new Swift Foundation.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->
- Add a new Swift Testing section in the Core Libraries page
- Update the Foundation section in the Core Libraries page

### Result:

<!-- _[After your change, what will change.]_ -->
The Swift Core Libraries page is updated with the latest libraries.
