### PR TITLE
feat(hero-anim): Add mobile hero animation logic. Misc cleanup relate…

### DIFF
--- a/assets/javascripts/new-javascripts/hero.js
+++ b/assets/javascripts/new-javascripts/hero.js
@@ -17,7 +17,6 @@ const heroAnimation = async (animContainer) => {
   // Skip to visible portion of animation when cropped on small screens
   const { left, width } = animContainer.getClientRects()[0]
   const offScreenDelta = Math.abs(left) / width
-  const initProgressVal = offScreenDelta
 
   const heroSwoops = [
     {

--- a/assets/javascripts/new-javascripts/hero.js
+++ b/assets/javascripts/new-javascripts/hero.js
@@ -29,7 +29,7 @@ const heroAnimation = async (animContainer) => {
       lineWidth: 210,
       debugColor: 'purple',
       image: null,
-      state: { progress: initProgressVal },
+      state: { progress: offScreenDelta },
     },
     {
       canvas: document.querySelector('#white-swoop-1'),
@@ -41,7 +41,7 @@ const heroAnimation = async (animContainer) => {
       lineWidth: 140,
       debugColor: 'red',
       image: null,
-      state: { progress: initProgressVal },
+      state: { progress: offScreenDelta },
     },
     {
       canvas: document.querySelector('#white-swoop-2'),
@@ -53,7 +53,7 @@ const heroAnimation = async (animContainer) => {
       lineWidth: 73.6,
       debugColor: 'cyan',
       image: null,
-      state: { progress: initProgressVal },
+      state: { progress: offScreenDelta },
     },
     {
       canvas: document.querySelector('#orange-swoop-bottom'),
@@ -65,7 +65,7 @@ const heroAnimation = async (animContainer) => {
       lineWidth: 202.2,
       debugColor: 'yellow',
       image: null,
-      state: { progress: initProgressVal },
+      state: { progress: offScreenDelta },
     },
     {
       canvas: document.querySelector('#orange-swoop-top'),
@@ -77,7 +77,7 @@ const heroAnimation = async (animContainer) => {
       lineWidth: 163.4,
       debugColor: 'green',
       image: null,
-      state: { progress: initProgressVal },
+      state: { progress: offScreenDelta },
     },
   ]
   const logo = {
@@ -88,7 +88,7 @@ const heroAnimation = async (animContainer) => {
     position: [610, 672.5],
     imagePath: '/assets/images/landing-page/hero/bird.png',
     image: null,
-    state: { progress: initProgressVal },
+    state: { progress: offScreenDelta },
   }
 
   const initSwoops = ({
@@ -206,7 +206,7 @@ const heroAnimation = async (animContainer) => {
     heroSwoops[1].state,
     {
       progress: 1,
-      duration: 950 - 950 * initProgressVal,
+      duration: 950 - 950 * offScreenDelta,
       onUpdate: () => swoopUpdate(heroSwoops[1]),
     },
     'start',
@@ -216,7 +216,7 @@ const heroAnimation = async (animContainer) => {
     heroSwoops[0].state,
     {
       progress: 1,
-      duration: 950 - 950 * initProgressVal,
+      duration: 950 - 950 * offScreenDelta,
       onUpdate: () => swoopUpdate(heroSwoops[0]),
     },
     'start',

--- a/assets/javascripts/new-javascripts/hero.js
+++ b/assets/javascripts/new-javascripts/hero.js
@@ -17,7 +17,7 @@ const heroAnimation = async (animContainer) => {
   // Skip to visible portion of animation when cropped on small screens
   const { left, width } = animContainer.getClientRects()[0]
   const offScreenDelta = Math.abs(left) / width
-  const initProgressVal = 0 + offScreenDelta
+  const initProgressVal = offScreenDelta
 
   const heroSwoops = [
     {

--- a/assets/stylesheets/new-stylesheets/pages/_index.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_index.scss
@@ -36,7 +36,7 @@ $icons: (
 }
 
 .animation-container {
-  @include noise();
+  aspect-ratio: 1248 / 1116;
   top: calc(66px - 9.5vw);
   left: 0;
   width: 57vw;


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

On smaller viewports, the hero graphic is cropped offscreen. This could cause a perceived performance issue as the animation playing offscreen is effectively an animation delay. This PR mainly adds logic to move the animation to the visible portion of the graphic. Additionally, this adds some cleanup and comments. 

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

### Modifications:

- Added animation offset
- Minor CSS cleanup
- Consolidated duplicate animation logic 
- Added explanatory comments

<!-- _[Describe the modifications you've done.]_ -->

### Result:

Hero animation starts from the visible portion of the container. 

<!-- _[After your change, what will change.]_ -->
