### PR TITLE
Fix Adaptable code block scrolling unnecessarily

### DIFF
--- a/_data/new-data/landing/callouts.yml
+++ b/_data/new-data/landing/callouts.yml
@@ -73,9 +73,10 @@
   subtitle: From microcontrollers to servers.
   text: "The only language that can span from embedded and kernel, to server and apps. Swift excels no matter where it’s used: from constrained environments like firmware where every byte counts, to cloud services handling billions of requests a day."
   code: |-
-    // Configure UART by direct register manipulation using Swift MMIO.
-    // Enables RX and TX, and sets baud rate to 115,200.
-    // Compiles down to an optimal assembly sequence with no overhead.
+    // Configure UART by direct register manipulation 
+    // using Swift MMIO. Enables RX and TX, and sets
+    // baud rate to 115,200. Compiles down to an
+    // optimal assembly sequence with no overhead.
 
     usart1.brr.modify { rw in
       rw.raw.brr_field = 16_000_000 / 115_200


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

The comments are too long, causing the code block to always wrap.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

Limit comment lengths to not exceed the 50 char limit.

### Result:

<!-- _[After your change, what will change.]_ -->
|Before|After|
|---|---|
|![CleanShot 2025-06-03 at 20 37 33](https://github.com/user-attachments/assets/3a00b929-70e1-4677-8b7e-089cea741f0c)|![CleanShot 2025-06-03 at 20 37 12](https://github.com/user-attachments/assets/d1c64f67-2f92-4d74-978b-e6d3330ec5cc)|

