### PR TITLE
Update links in gRPC Swift 2 post

### DIFF
--- a/_posts/2025-02-14-grpc-swift-2.md
+++ b/_posts/2025-02-14-grpc-swift-2.md
@@ -166,7 +166,7 @@ gRPC Swift 2 was designed with flexibility in mind. It's distributed as a
 collection of packages, allowing you to pick and choose the components which
 best suit your needs. These features are provided by the following packages:
 
-* [grpc/grpc-swift](https://github.com/grpc/grpc-swift) provides runtime
+* [grpc/grpc-swift-2](https://github.com/grpc/grpc-swift-2) provides runtime
   abstractions and types.
 * [grpc/grpc-swift-nio-transport](https://github.com/grpc/grpc-swift-nio-transport)
   implements client and server transports using HTTP/2 and is built on top of
@@ -183,11 +183,11 @@ best suit your needs. These features are provided by the following packages:
 ## Next Steps
 
 To get started with gRPC Swift 2 check out the [tutorials and
-documentation](https://swiftpackageindex.com/grpc/grpc-swift/documentation)
+documentation](https://swiftpackageindex.com/grpc/grpc-swift-2/documentation)
 which are hosted on the Swift Package Index, or try out one of the examples in
-the [grpc/grpc-swift](https://github.com/grpc/grpc-swift) repository.
+the [grpc/grpc-swift-2](https://github.com/grpc/grpc-swift-2) repository.
 
 If you have feature requests, want to report a bug, or would like to contribute
 to the project then please reach out to us on
-[GitHub](https://github.com/grpc/grpc-swift) or join us on the [Swift
+[GitHub](https://github.com/grpc/grpc-swift-2) or join us on the [Swift
 forums](https://forums.swift.org/c/related-projects/grpc-swift/). Let’s connect!


### PR DESCRIPTION

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

gRPC Swift 2 moved to a new repo; the links in the gRPC post should be updated to reflect that move.

### Modifications:

Update the links

### Result:

The links are up-to-date