### PR TITLE
Fix code block tabs on mobile

### DIFF
--- a/assets/stylesheets/new-stylesheets/pages/_get-started.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_get-started.scss
@@ -554,9 +554,10 @@
 
   @media only screen and (max-width: 768px) {
     nav {
+     width: 100%;
+
       ul {
         white-space: nowrap;
-        width: calc(100% - 59px);
       }
     }
   }


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

Fixes broken code block tabs.

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

The code block tabs don't work properly on mobile:
* On the install page, the Fish tab is not visible
* On the CLI tools page, it doesn't scroll all the way to the last item.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Fixed the width of the tabs
  - I'm not sure what the negative 59px was for?

### Result:

<!-- _[After your change, what will change.]_ -->

### Install page

|Before|After|
|---|---|
|![CleanShot 2025-06-04 at 22 08 14](https://github.com/user-attachments/assets/89017e90-4192-4e93-b3b8-060488fac01a)|![CleanShot 2025-06-04 at 22 08 22](https://github.com/user-attachments/assets/68f96a5f-7901-479d-a6dd-5f8470af5eaa)|

### CLI tools page

|Before|After|
|---|---|
|![CleanShot 2025-06-04 at 22 08 02](https://github.com/user-attachments/assets/ae958fcf-07e7-4ed8-be3b-abd3f8463411)|![CleanShot 2025-06-04 at 22 07 32](https://github.com/user-attachments/assets/e8ac8f3c-a026-418c-877a-4d9749b87d78)|
