### PR TITLE
Add focus outline on code block tab button back for better accessibility

### DIFF
--- a/assets/stylesheets/new-stylesheets/pages/_get-started.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_get-started.scss
@@ -468,7 +468,6 @@
     padding-left: 0 !important;
 
     button {
-      outline: none;
       border: none;
       background: none;
 


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

Restoring the focus outline on the code block tabs to make it easier to navigate the website using the keyboard.

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

It's good UX and useful for accessibility reasons to show where you are on the website when navigate using the tab key. Focus outlines should not be removed.

I simply added it back by removing `outline: none`.

We can consider a custom outline implementation if we want, but let's at least add back the default one in the meantime.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

### Result:

<!-- _[After your change, what will change.]_ -->

|Before|After|
|---|---|
|![CleanShot 2025-06-04 at 22 25 26](https://github.com/user-attachments/assets/5281bc1e-c78f-400b-92d8-42621ef2caf0)|![CleanShot 2025-06-04 at 22 25 02](https://github.com/user-attachments/assets/bd0cd3d5-2964-401e-8e05-62f3449ef7d9)|
