### PR TITLE
Use fancy underline on install page as well + create helper mixin

### DIFF
--- a/assets/stylesheets/new-stylesheets/_helpers.scss
+++ b/assets/stylesheets/new-stylesheets/_helpers.scss
@@ -197,6 +197,6 @@
 
 @mixin underline {
   text-decoration: underline;
-  text-decoration-color: rgba(255, 255, 255, 0.5);
+  text-decoration-color: color-mix(in srgb, currentColor 50%, transparent);
   text-underline-offset: 2px;
 }

--- a/assets/stylesheets/new-stylesheets/_helpers.scss
+++ b/assets/stylesheets/new-stylesheets/_helpers.scss
@@ -194,3 +194,9 @@
     white-space: normal;
   }
 }
+
+@mixin underline {
+  text-decoration: underline;
+  text-decoration-color: rgba(255, 255, 255, 0.5);
+  text-underline-offset: 2px;
+}

--- a/assets/stylesheets/new-stylesheets/includes/callout/_base.scss
+++ b/assets/stylesheets/new-stylesheets/includes/callout/_base.scss
@@ -37,9 +37,7 @@
       @include link-with-right-arrow();
       display: block;
       color: white;
-      text-decoration: underline;
-      text-decoration-color: rgba(255, 255, 255, 0.5);
-      text-underline-offset: 2px;
+      @include underline;
       margin-top: 14px;
 
       i {

--- a/assets/stylesheets/new-stylesheets/pages/_install.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_install.scss
@@ -49,7 +49,7 @@
           @include link-with-right-arrow;
           margin-top: 10px;
           display: flex;
-          text-decoration: underline;
+          @include underline;
 
           &.block {
             justify-content: center;


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

Add helper mixin for underline and use on install page too.

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

We have a "fancy" underline on the landing page. We should use this on the install page as well for consistency.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Added a `mixin` that can be used using `@include`
- Use it on the landing page
- Use it on the install page

### Result:

<!-- _[After your change, what will change.]_ -->

|Before|After|
|---|---|
|![CleanShot 2025-06-04 at 22 17 49](https://github.com/user-attachments/assets/2d7ff1ec-e0af-4561-8e07-bf88745096aa)|![CleanShot 2025-06-04 at 22 17 31](https://github.com/user-attachments/assets/9c2312f2-ed21-46ff-91dd-76a4c5cfee5f)|