### PR TITLE
Fix anchor scroll

### DIFF
--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -178,6 +178,8 @@ cite {
 }
 
 .header-with-anchor {
+  scroll-margin-top: 80px;
+
   a {
     display: none;
     color: var(--color-text);


### PR DESCRIPTION
### Motivation:

When the user clicks on anchors the page scrolls and anchor header goes under the navigation

### Result:

The header with anchor scrolls without going under the navigation
