### PR TITLE
Replace fish's deprecated . command with source command

### DIFF
--- a/_data/new-data/install/linux/releases.yml
+++ b/_data/new-data/install/linux/releases.yml
@@ -16,7 +16,7 @@ latest-release:
           curl -O https://download.swift.org/swiftly/linux/swiftly-(uname -m).tar.gz && \
           tar zxf swiftly-(uname -m).tar.gz && \
           ./swiftly init --quiet-shell-followup && \
-          set -q SWIFTLY_HOME_DIR && . "$SWIFTLY_HOME_DIR/env.fish" || . ~/.local/share/swiftly/env.fish
+          set -q SWIFTLY_HOME_DIR && source "$SWIFTLY_HOME_DIR/env.fish" || source ~/.local/share/swiftly/env.fish
     links:
       - href: 'https://raw.githubusercontent.com/swiftlang/swiftly/refs/heads/main/LICENSE.txt'
         copy: 'License: Apache-2.0'

--- a/_data/new-data/install/macos/releases.yml
+++ b/_data/new-data/install/macos/releases.yml
@@ -16,7 +16,7 @@ latest-release:
           curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg && \
           installer -pkg swiftly.pkg -target CurrentUserHomeDirectory && \
           ~/.swiftly/bin/swiftly init --quiet-shell-followup && \
-          set -q SWIFTLY_HOME_DIR && . "$SWIFTLY_HOME_DIR/env.fish" || . ~/.swiftly/env.fish
+          set -q SWIFTLY_HOME_DIR && source "$SWIFTLY_HOME_DIR/env.fish" || source ~/.swiftly/env.fish
     links:
       - href: 'https://raw.githubusercontent.com/swiftlang/swiftly/refs/heads/main/LICENSE.txt'
         copy: 'License: Apache-2.0'


### PR DESCRIPTION
I replaced fish's deprecated . command with source command in the installation instructions.

### Motivation:

fish's . command is deprecated and it's just an alias of source command. Moreover, according to the following documentation, . command is planned to be removed in the future version of fish.

https://fishshell.com/docs/current/cmds/source.html#description

### Modifications:

- https://www.swift.org/install/linux/
  - replaced `.` with `source` in the instructions for fish
- https://www.swift.org/install/macos/
  - replaced `.` with `source` in the instructions for fish

### Result:

Users will no longer need to use deprecated commands when installing Swift.
