### PR TITLE
Add support for Wasm sdk support

### DIFF
--- a/_data/new-data/install/linux/dev.yml
+++ b/_data/new-data/install/linux/dev.yml
@@ -1,0 +1,15 @@
+latest-dev:
+  swiftly:
+    pre-code-text: |
+      Swiftly supports installing development snapshot toolchains. For example, you can install the latest available snapshot for the next major release using the “main-snapshot” selector and prepare your code for when it arrives.
+    headline: Swiftly
+    tabs:
+      - label: main
+        code: |-
+          swiftly install main-snapshot
+      - label: release/6.2
+        code: |-
+          swiftly install 6.2-snapshot
+    links:
+      - href: '/install/linux/swiftly'
+        copy: 'Instructions'

--- a/_includes/new-includes/components/linux-releases.html
+++ b/_includes/new-includes/components/linux-releases.html
@@ -164,8 +164,15 @@
   <h3>Static Linux SDK</h3>
   <div>
     <p class="content-copy">
-      <a class="content-link" href="https://www.swift.org/documentation/articles/static-linux-getting-started.html">Instructions</a>
+      <a class="content-link" href="/documentation/articles/static-linux-getting-started.html">Instructions</a>
     </p>
   </div>
   {% include new-includes/components/static-linux-sdk-dev.html %}
+  <h3>Swift SDK for WebAssembly</h3>
+  <div>
+    <p class="content-copy">
+      <a class="content-link" href="/documentation/articles/wasm-getting-started.html">Instructions</a>
+    </p>
+  </div>
+  {% include new-includes/components/wasm-sdk-dev.html %}
 </div>

--- a/_includes/new-includes/components/static-linux-sdk-dev.html
+++ b/_includes/new-includes/components/static-linux-sdk-dev.html
@@ -1,5 +1,5 @@
 {% assign static_sdk_dev_builds = site.data.builds.development.static_sdk | sort: 'date' | reverse %}
-{% assign static_sdk_6_1_builds = site.data.builds.swift-6_1-branch.static_sdk | sort: 'date' | reverse %}
+{% assign static_sdk_6_2_builds = site.data.builds.swift-6_2-branch.static-sdk | sort: 'date' | reverse %}
 
 <div class="releases-grid">
     <div class="release-box section">
@@ -28,21 +28,21 @@
     <div class="release-box section">
         <div class="content">
         <div class="code-box content-wrapper">
-            <h2>release/6.1</h2>
+            <h2>release/6.2</h2>
             <p class="body-copy">
-            <small>{{ static_sdk_6_1_builds.first.date | date: '%B %-d, %Y' }}</small><br />
+            <small>{{ static_sdk_6_2_builds.first.date | date: '%B %-d, %Y' }}</small><br />
             Static Linux SDK - Cross compile to Linux.
             <br /><br />
-            {% assign base_url = "https://download.swift.org/development/static-sdk/" | append: static_sdk_6_1_builds.first.dir | append: "/" | append: static_sdk_6_1_builds.first.download %}
-            {% assign command = "swift sdk install " | append: base_url | append: " --checksum " | append: static_sdk_6_1_builds.first.checksum %}
+            {% assign base_url = "https://download.swift.org/swift-6.2-branch/static-sdk/" | append: static_sdk_6_2_builds.first.dir | append: "/" | append: static_sdk_6_2_builds.first.download %}
+            {% assign command = "swift sdk install " | append: base_url | append: " --checksum " | append: static_sdk_6_2_builds.first.checksum %}
             <button onclick="copyToClipboard(this, '{{ command | escape }}')">
                 Copy install command
             </button>
             </p>
             <div class="link-wrapper">
             <div class="link-group">
-                <a href="https://download.swift.org/swift-6.1-branch/static-sdk/{{ static_sdk_6_1_builds.first.dir }}/{{ static_sdk_6_1_builds.first.download }}" class="body-copy">Download Linux Static SDK</a> |
-                <a href="https://download.swift.org/swift-6.1-branch/static-sdk/{{ static_sdk_6_1_builds.first.dir }}/{{ static_sdk_6_1_builds.first.download_signature }}" class="body-copy">Signature (PGP)</a>
+                <a href="https://download.swift.org/swift-6.2-branch/static-sdk/{{ static_sdk_6_2_builds.first.dir }}/{{ static_sdk_6_2_builds.first.download }}" class="body-copy">Download Linux Static SDK</a> |
+                <a href="https://download.swift.org/swift-6.2-branch/static-sdk/{{ static_sdk_6_2_builds.first.dir }}/{{ static_sdk_6_2_builds.first.download_signature }}" class="body-copy">Signature (PGP)</a>
             </div>
             </div>
         </div>

--- a/_includes/new-includes/components/wasm-sdk-dev.html
+++ b/_includes/new-includes/components/wasm-sdk-dev.html
@@ -1,0 +1,51 @@
+{% assign wasm_sdk_dev_builds = site.data.builds.development.wasm-sdk | sort: 'date' | reverse %}
+{% assign wasm_sdk_6_2_builds = site.data.builds.swift-6_2-branch.wasm-sdk | sort: 'date' | reverse %}
+
+<div class="releases-grid">
+    <div class="release-box section">
+        <div class="content">
+        <div class="code-box content-wrapper">
+            <h2>main</h2>
+            <p class="body-copy">
+            <small>{{ wasm_sdk_dev_builds.first.date | date: '%B %-d, %Y' }}</small><br />
+            Swift SDKs for WebAssembly
+            <br /><br />
+            {% assign base_url = "https://download.swift.org/development/wasm-sdk/" | append: wasm_sdk_dev_builds.first.dir | append: "/" | append: wasm_sdk_dev_builds.first.download %}
+            {% assign command = "swift sdk install " | append: base_url | append: " --checksum " | append: wasm_sdk_dev_builds.first.checksum %}
+            <button onclick="copyToClipboard(this, '{{ command | escape }}')">
+                Copy install command
+            </button>
+            </p>
+            <div class="link-wrapper">
+            <div class="link-group">
+                <a href="https://download.swift.org/development/wasm-sdk/{{ wasm_sdk_dev_builds.first.dir }}/{{ wasm_sdk_dev_builds.first.download }}" class="body-copy">Download Wasm SDK</a> |
+                <a href="https://download.swift.org/development/wasm-sdk/{{ wasm_sdk_dev_builds.first.dir }}/{{ wasm_sdk_dev_builds.first.download_signature }}" class="body-copy">Signature (PGP)</a>
+            </div>
+            </div>
+        </div>
+        </div>
+    </div>
+    <div class="release-box section">
+        <div class="content">
+        <div class="code-box content-wrapper">
+            <h2>release/6.2</h2>
+            <p class="body-copy">
+            <small>{{ wasm_sdk_6_2_builds.first.date | date: '%B %-d, %Y' }}</small><br />
+            Swift SDKs for WebAssembly
+            <br /><br />
+            {% assign base_url = "https://download.swift.org/swift-6.2-branch/wasm-sdk/" | append: wasm_sdk_6_2_builds.first.dir | append: "/" | append: wasm_sdk_6_2_builds.first.download %}
+            {% assign command = "swift sdk install " | append: base_url | append: " --checksum " | append: wasm_sdk_6_2_builds.first.checksum %}
+            <button onclick="copyToClipboard(this, '{{ command | escape }}')">
+                Copy install command
+            </button>
+            </p>
+            <div class="link-wrapper">
+            <div class="link-group">
+                <a href="https://download.swift.org/swift-6.2-branch/wasm-sdk/{{ wasm_sdk_6_2_builds.first.dir }}/{{ wasm_sdk_6_2_builds.first.download }}" class="body-copy">Download Wasm SDK</a> |
+                <a href="https://download.swift.org/swift-6.2-branch/wasm-sdk/{{ wasm_sdk_6_2_builds.first.dir }}/{{ wasm_sdk_6_2_builds.first.download_signature }}" class="body-copy">Signature (PGP)</a>
+            </div>
+            </div>
+        </div>
+        </div>
+    </div>
+</div>

--- a/install/linux/index.md
+++ b/install/linux/index.md
@@ -21,6 +21,29 @@ title: Install Swift - Linux
       {% include new-includes/components/static-linux-sdk.html %}
     </div>
   </div>
+  <h2>Development Snapshots</h2>
+  <div>
+    <p class="content-copy">Swift snapshots are prebuilt binaries that are automatically created from the branch. These snapshots are not official releases. They have gone through automated unit testing, but they have not gone through the full testing that is performed for official releases.</p>
+  </div>
+  <div class="release-box section">
+    <div class="content">
+      {% include new-includes/components/code-box.html with-tabs = true content = site.data.new-data.install.linux.dev.latest-dev.swiftly %}
+    </div>
+  </div>
+  <h3>Static Linux SDK</h3>
+  <div>
+    <p class="content-copy">
+      <a class="content-link" href="/documentation/articles/static-linux-getting-started.html">Instructions</a>
+    </p>
+  </div>
+  {% include new-includes/components/static-linux-sdk-dev.html %}
+   <h3>Swift SDK for WebAssembly</h3>
+  <div>
+    <p class="content-copy">
+      <a class="content-link" href="/documentation/articles/wasm-getting-started.html">Instructions</a>
+    </p>
+  </div>
+  {% include new-includes/components/wasm-sdk-dev.html %}
   <div class="callout">
     <div>
       <p class="content-copy">

--- a/install/macos/index.md
+++ b/install/macos/index.md
@@ -120,4 +120,11 @@ title: Install Swift - macOS
     </p>
   </div>
   {% include new-includes/components/static-linux-sdk-dev.html %}
+   <h3>Swift SDK for WebAssembly</h3>
+  <div>
+    <p class="content-copy">
+      <a class="content-link" href="/documentation/articles/wasm-getting-started.html">Instructions</a>
+    </p>
+  </div>
+  {% include new-includes/components/wasm-sdk-dev.html %}
 </div>


### PR DESCRIPTION
I added support for nightly snapshots via swiftly. Additionally, I added a section for static SDK and WASM SDK on the Linux and macOS install page. 

## Linux install page
![127 0 0 1_4000_install_linux_ (2)](https://github.com/user-attachments/assets/64c04fe9-e6ea-457d-99bc-d97ff7c91f39)

## macOS install page
![127 0 0 1_4000_install_macos_ (3)](https://github.com/user-attachments/assets/036947a4-5a7b-4288-b7ed-0df6a600a8f3)
