### PR TITLE
[Install] Include VSCode IDE info on the Windows and Linux install page

### DIFF
--- a/_data/new-data/install/windows/releases.yml
+++ b/_data/new-data/install/windows/releases.yml
@@ -13,5 +13,13 @@ latest-release:
     links:
       - href: "/install/windows/winget/"
         copy: "Additional details included in Instructions"
+  vscode:
+    pre-code-text: Visual Studio Code is a cross-platform and extensible editor that supports Swift through the Swift extension, which provides intelligent editor functionality as well as debugging and test support.
+    headline: Visual Studio Code
+    links:
+      - href: 'https://marketplace.visualstudio.com/items?itemName=swiftlang.swift-vscode'
+        copy: 'Install Swift extension'
+      - href: 'https://code.visualstudio.com/docs/languages/swift'
+        copy: 'Documentation'
       - href: "https://www.swift.org/tools/#editors"
-        copy: "Editors"
+        copy: "Other Editors"

--- a/install/linux/index.md
+++ b/install/linux/index.md
@@ -21,6 +21,11 @@ title: Install Swift - Linux
       {% include new-includes/components/static-linux-sdk.html %}
     </div>
   </div>
+  <div class="release-box section">
+    <div class="content">
+      {% include new-includes/components/code-box.html content = site.data.new-data.install.windows.releases.latest-release.vscode%}
+    </div>
+  </div>
   <h2>Development Snapshots</h2>
   <div>
     <p class="content-copy">Swift snapshots are prebuilt binaries that are automatically created from the branch. These snapshots are not official releases. They have gone through automated unit testing, but they have not gone through the full testing that is performed for official releases.</p>

--- a/install/windows/index.md
+++ b/install/windows/index.md
@@ -18,6 +18,11 @@ title: Install Swift - Windows
       {% include new-includes/components/code-box.html content = site.data.new-data.install.windows.releases.latest-release.winget %}
     </div>
   </div>
+  <div class="release-box section">
+    <div class="content">
+      {% include new-includes/components/code-box.html content = site.data.new-data.install.windows.releases.latest-release.vscode%}
+    </div>
+  </div>
   <h2>Alternative install options</h2>
   <div class="releases-grid">
     <div class="release-box section">


### PR DESCRIPTION
We are currently missing editor information on the install page for Windows and Linux. This change will highlight the Swift extension for VSCode on the Windows and Linux pages. 

<img width="658" alt="Screenshot 2025-06-08 at 5 35 57 PM" src="https://github.com/user-attachments/assets/4e6a2e2d-327d-48d1-8fa2-b232f03870f1" />
