### PR TITLE
Updated Community Showcase packages for June

### DIFF
--- a/_data/packages/packages.yml
+++ b/_data/packages/packages.yml
@@ -9,55 +9,55 @@ categories:
       organised via [this thread in the Swift Forums](https://forums.swift.org/t/68168)
       and curated by the [Swift Website Workgroup](https://www.swift.org/website-workgroup/).
     packages:
-      - name: Anodize
-        description: Adds type safety to Metal shaders, enabling Swift to interact with
-          Metal kernels without managing binding indices. Enhances code safety and simplifies
-          GPU kernel integration.
-        owner: Audulus LLC
-        swift_compatibility: 6.0+
+      - name: package-swift-lsp
+        description: Provides a Language Server Protocol (LSP) implementation for smart
+          code completion and contextual information in SwiftPM's `Package.swift` manifest
+          files.
+        owner: Vasiliy Kattouf
+        swift_compatibility: 6.1+
         platform_compatibility:
           - Apple
         platform_compatibility_tooltip: Apple (macOS)
         license: MIT
-        url: https://swiftpackageindex.com/audulus/Anodize
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/123){:target='_blank'}.
-      - name: Noora
-        description: Enhances terminal aesthetics for Swift CLIs with a customizable design
-          system, improving consistency and readability in command-line interfaces.
-        owner: Tuist
-        swift_compatibility: 6.0+
+        url: https://swiftpackageindex.com/kattouf/package-swift-lsp
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/136){:target='_blank'}.
+      - name: Harmonize
+        description: Harmonize enhances Swift codebase consistency by allowing developers
+          to write custom linter rules as unit tests, focusing on architectural and structural
+          guidelines over style conventions.
+        owner: Perry Street Software, Inc
+        swift_compatibility: 5.9+
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
-        license: MIT
-        url: https://swiftpackageindex.com/tuist/Noora
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/120){:target='_blank'}.
-      - name: swift-aws-lambda-runtime
-        description: Facilitates building serverless functions in Swift for AWS Lambda,
-          offering features like JSON handling, response streaming, and background tasks,
-          while emphasizing performance, safety, and developer control.
-        owner: Swift on Server
-        swift_compatibility: 5.9+
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS) and Linux
+        license: Apache 2.0
+        url: https://swiftpackageindex.com/perrystreetsoftware/Harmonize
+        note: Discussed on [Episode 57 of Swift Package Indexing](https://share.transistor.fm/s/32b618c5){:target='_blank'}.
+      - name: HasLazyServer
+        description: Handles JSON type inconsistencies by providing Codable types that
+          normalize and log type mismatches, aiding in decoding unpredictable data.
+        owner: southkin
+        swift_compatibility: 6.0+
         platform_compatibility:
           - Apple
           - Linux
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
           Linux
-        license: Apache 2.0
-        url: https://swiftpackageindex.com/swift-server/swift-aws-lambda-runtime
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/127){:target='_blank'}.
-      - name: swift-package-registry-service
-        description: An implementation of the Swift Package Registry Service which proxies
-          the Github API.
-        owner: CrowdStrike
+        license: MIT
+        url: https://swiftpackageindex.com/southkin/HasLazyServer
+        note: Discussed on [Episode 56 of Swift Package Indexing](https://share.transistor.fm/s/135e7db3){:target='_blank'}.
+      - name: Redline
+        description: Visualize and debug SwiftUI layouts by inspecting positions, sizes,
+          spacings, and alignment guides to ensure implementations match design specifications.
+        owner: "Robb B\xF6hnke"
         swift_compatibility: 6.0+
         platform_compatibility:
           - Apple
-        platform_compatibility_tooltip: Apple (macOS, visionOS)
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS)
         license: MIT
-        url: https://swiftpackageindex.com/CrowdStrike/swift-package-registry-service
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/128){:target='_blank'}.
+        url: https://swiftpackageindex.com/robb/Redline
+        note: Discussed on [Episode 57 of Swift Package Indexing](https://share.transistor.fm/s/32b618c5){:target='_blank'}.
   - name: Packages with Macros
     slug: macros
     brief: New in Swift 5.9, Swift packages can include macro targets. Browse a selection

--- a/_data/packages/showcase-history.yml
+++ b/_data/packages/showcase-history.yml
@@ -1,6 +1,58 @@
 years:
   - year: 2025
     months:
+      - month: May
+        slug: may
+        packages:
+          - name: Anodize
+            description: Adds type safety to Metal shaders, enabling Swift to interact with
+              Metal kernels without managing binding indices. Enhances code safety and simplifies
+              GPU kernel integration.
+            owner: Audulus LLC
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (macOS)
+            license: MIT
+            url: https://swiftpackageindex.com/audulus/Anodize
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/123){:target='_blank'}.
+          - name: Noora
+            description: Enhances terminal aesthetics for Swift CLIs with a customizable
+              design system, improving consistency and readability in command-line interfaces.
+            owner: Tuist
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/tuist/Noora
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/120){:target='_blank'}.
+          - name: swift-aws-lambda-runtime
+            description: Facilitates building serverless functions in Swift for AWS Lambda,
+              offering features like JSON handling, response streaming, and background tasks,
+              while emphasizing performance, safety, and developer control.
+            owner: Swift on Server
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/swift-server/swift-aws-lambda-runtime
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/127){:target='_blank'}.
+          - name: swift-package-registry-service
+            description: An implementation of the Swift Package Registry Service which proxies
+              the Github API.
+            owner: CrowdStrike
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (macOS, visionOS)
+            license: MIT
+            url: https://swiftpackageindex.com/CrowdStrike/swift-package-registry-service
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/128){:target='_blank'}.
       - month: April
         slug: april
         packages:


### PR DESCRIPTION
This update contains the [Community Showcase packages](https://www.swift.org/packages/showcase.html) for June.

Packages in the Community Showcase are nominated by the community in [this thread on the Swift forums](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168) and voted on by the [SWWG](https://www.swift.org/website-workgroup/).

![Screenshot 2025-06-09 at 17 36 59@2x](https://github.com/user-attachments/assets/f19464e8-a2cc-4917-9bda-b9cee7d12bee)
