### PR TITLE
[cxx-interop] Add SWIFT_RETUNRS_(UN)RETAINED discussions to C++ interop docs

### DIFF
--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -1255,7 +1255,7 @@ object.doSomething()
 // `object` will be released here.
 ```
 
-#### Calling conventions for returning Shared Reference Types
+#### Calling conventions when returning Shared Reference Types from C++ to Swift
 
 When C++ functions and methods return `SWIFT_SHARED_REFERENCE` types, it is necessary to specify the ownership of the returned value.
 For this you should use the `SWIFT_RETURNS_RETAINED` and `SWIFT_RETURNS_UNRETAINED` annotations on functions and methods.

--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -1261,7 +1261,7 @@ To specify the ownership of returned `SWIFT_SHARED_REFERENCE` types, use the `SW
 // Returns +1 ownership; Swift will take responsibility for releasing it.
 SharedObject* makeOwnedObject() SWIFT_RETURNS_RETAINED;
 
-// Returns +0 ownership; the caller must ensure the object stays alive.
+// Returns +0 ownership; the caller must ensure the object stays alive by retaining it before use.
 SharedObject* makeUnownedObject() SWIFT_RETURNS_UNRETAINED;
 ```
 
@@ -1271,12 +1271,12 @@ let owned = makeOwnedObject()
 owned.doSomething()
 // `owned` is automatically released when it goes out of scope
 
-let unowned = makeUnownedObject()
-unowned.doSomething()
-// make sure `unowned` remains valid while in use
+let unOwned = makeUnownedObject()
+unOwned.doSomething()
+// Swift makes sure `unOwned` remains valid while in use by calling an explicit retain operation.
 ```
 
-These ownership annotations are also supported in Objective-C or Objective-C++ functions that return C++ `SWIFT_SHARED_REFERENCE` types.
+These ownership annotations are also supported in Objective-C++ functions that return C++ `SWIFT_SHARED_REFERENCE` types.
 
 
 ### Inheritance and Virtual Member Functions

--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -1255,29 +1255,32 @@ object.doSomething()
 // `object` will be released here.
 ```
 
-To specify the ownership of returned `SWIFT_SHARED_REFERENCE` types, use the `SWIFT_RETURNS_RETAINED` and `SWIFT_RETURNS_UNRETAINED` annotations on C++ functions and methods. These annotations tell the Swift compiler whether the type is returned as `+1` (retained) or `+0` (unretained). This is necessary to ensure that appropriate `retain`/`release` operations are inserted at the boundary:
+#### Calling convention for returning shared reference types
+
+When C++ functions and methods return `SWIFT_SHARED_REFERENCE` types, it is necessary to specify the ownership of the returned value. For this you can use the `SWIFT_RETURNS_RETAINED` and `SWIFT_RETURNS_UNRETAINED` annotations on C++ functions and methods. These annotations tell the Swift compiler whether the type is returned as `+1` (retained) or `+0` (unretained). This is necessary to ensure that appropriate `retain`/`release` operations are inserted at the boundary:
 
 ```c++
 // Returns +1 ownership; Swift will take responsibility for releasing it.
 SharedObject* makeOwnedObject() SWIFT_RETURNS_RETAINED;
 
 // Returns +0 ownership; the caller must ensure the object stays alive by retaining it before use.
-SharedObject* makeUnownedObject() SWIFT_RETURNS_UNRETAINED;
+SharedObject* getUnownedObject() SWIFT_RETURNS_UNRETAINED;
 ```
 
 These ownership conventions are reflected naturally in Swift:
 ```swift
 let owned = makeOwnedObject()
 owned.doSomething()
-// `owned` is automatically released when it goes out of scope
+// `owned` is automatically released when it goes out of scope.
 
-let unOwned = makeUnownedObject()
+let unOwned = getUnownedObject()
 unOwned.doSomething()
-// Swift makes sure `unOwned` remains valid while in use by calling an explicit retain operation.
+// Swift makes sure `unOwned` remains valid while in use by calling a retain operation.
 ```
 
 These ownership annotations are also supported in Objective-C++ functions that return C++ `SWIFT_SHARED_REFERENCE` types.
 
+Note that the Swift compiler will automatically infer the ownership conventons for Swift functions returning `SWIFT_SHARED_REFERENCE` types. See [Exposing C++ Shared Reference Types back from Swift](#exposing-c-shared-reference-types-back-from-swift) for calling Swift functions returning `SWIFT_SHARED_REFERENCE` types from C++.
 
 ### Inheritance and Virtual Member Functions
 

--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -1255,6 +1255,30 @@ object.doSomething()
 // `object` will be released here.
 ```
 
+To specify the ownership of returned `SWIFT_SHARED_REFERENCE` types, use the `SWIFT_RETURNS_RETAINED` and `SWIFT_RETURNS_UNRETAINED` annotations on C++ functions and methods. These annotations tell the Swift compiler whether the type is returned as `+1` (retained) or `+0` (unretained). This is necessary to ensure that appropriate `retain`/`release` operations are inserted at the boundary:
+
+```c++
+// Returns +1 ownership; Swift will take responsibility for releasing it.
+SharedObject* makeOwnedObject() SWIFT_RETURNS_RETAINED;
+
+// Returns +0 ownership; the caller must ensure the object stays alive.
+SharedObject* makeUnownedObject() SWIFT_RETURNS_UNRETAINED;
+```
+
+These ownership conventions are reflected naturally in Swift:
+```swift
+let owned = makeOwnedObject()
+owned.doSomething()
+// `owned` is automatically released when it goes out of scope
+
+let unowned = makeUnownedObject()
+unowned.doSomething()
+// make sure `unowned` remains valid while in use
+```
+
+These ownership annotations are also supported in Objective-C or Objective-C++ functions that return C++ `SWIFT_SHARED_REFERENCE` types.
+
+
 ### Inheritance and Virtual Member Functions
 
 Similar to value types, casting an instance of a derived reference type to a

--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -1255,32 +1255,34 @@ object.doSomething()
 // `object` will be released here.
 ```
 
-#### Calling convention for returning shared reference types
+#### Calling conventions for returning Shared Reference Types
 
-When C++ functions and methods return `SWIFT_SHARED_REFERENCE` types, it is necessary to specify the ownership of the returned value. For this you can use the `SWIFT_RETURNS_RETAINED` and `SWIFT_RETURNS_UNRETAINED` annotations on C++ functions and methods. These annotations tell the Swift compiler whether the type is returned as `+1` (retained) or `+0` (unretained). This is necessary to ensure that appropriate `retain`/`release` operations are inserted at the boundary:
+When C++ functions and methods return `SWIFT_SHARED_REFERENCE` types, it is necessary to specify the ownership of the returned value.
+For this you should use the `SWIFT_RETURNS_RETAINED` and `SWIFT_RETURNS_UNRETAINED` annotations on functions and methods.
+These annotations tell the Swift compiler whether the type is returned as `+1` (retained) or `+0` (unretained).
 
 ```c++
-// Returns +1 ownership; Swift will take responsibility for releasing it.
+// Returns +1 ownership.
 SharedObject* makeOwnedObject() SWIFT_RETURNS_RETAINED;
 
-// Returns +0 ownership; the caller must ensure the object stays alive by retaining it before use.
-SharedObject* getUnownedObject() SWIFT_RETURNS_UNRETAINED;
+// Returns +0 ownership.
+SharedObject* getUnOwnedObject() SWIFT_RETURNS_UNRETAINED;
 ```
 
-These ownership conventions are reflected naturally in Swift:
+These annotations are necessary to ensure that appropriate `retain`/`release` operations are inserted at the boundary:
+
 ```swift
 let owned = makeOwnedObject()
 owned.doSomething()
-// `owned` is automatically released when it goes out of scope.
+// `owned` is already at +1, so no further retain is needed here
 
-let unOwned = getUnownedObject()
+let unOwned = getUnOwnedObject()
+// Swift inserts a retain operation on `unowned` here to bring it to +1.
 unOwned.doSomething()
-// Swift makes sure `unOwned` remains valid while in use by calling a retain operation.
 ```
 
-These ownership annotations are also supported in Objective-C++ functions that return C++ `SWIFT_SHARED_REFERENCE` types.
-
-Note that the Swift compiler will automatically infer the ownership conventons for Swift functions returning `SWIFT_SHARED_REFERENCE` types. See [Exposing C++ Shared Reference Types back from Swift](#exposing-c-shared-reference-types-back-from-swift) for calling Swift functions returning `SWIFT_SHARED_REFERENCE` types from C++.
+Note that the Swift compiler will automatically infer the ownership conventons for Swift functions returning `SWIFT_SHARED_REFERENCE` types.
+See [Exposing C++ Shared Reference Types back from Swift](#exposing-c-shared-reference-types-back-from-swift) for calling Swift functions returning `SWIFT_SHARED_REFERENCE` types from C++.
 
 ### Inheritance and Virtual Member Functions
 


### PR DESCRIPTION
Documenting the usage of `SWIFT_RETUNRS_(UN)RETAINED` annotations to specify the ownership convention of the returned `SWIFT_SHARED_REFERENCE` types from C++ functions and methods

rdar://116817243
