### PR TITLE
[cxx-interop] Add documentation about inferring SWIFT_SHARED_REFERENCE in c++ inheritance

### DIFF
--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -1255,6 +1255,9 @@ object.doSomething()
 // `object` will be released here.
 ```
 
+### Inference for Derived Types
+Swift compiler automatically infers the ```SWIFT_SHARED_REFERENCE``` annotation for C++ types that inherit from a base type annotated with ```SWIFT_SHARED_REFERENCE```. These derived types are imported as Swift reference types or Swift class types that use the same ```retain``` and ```release``` functions as the base type. No additional annotation is required on the derived types.
+
 ### Inheritance and Virtual Member Functions
 
 Similar to value types, casting an instance of a derived reference type to a

--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -1255,9 +1255,10 @@ object.doSomething()
 // `object` will be released here.
 ```
 
-### Inference for Derived Types
+### Inference of Shared Reference behaviour in Derived Types
 
-Swift compiler automatically infers the ```SWIFT_SHARED_REFERENCE``` annotation for C++ types that inherit from a base type annotated with ```SWIFT_SHARED_REFERENCE```. These derived types are also imported as a reference type in Swift that use the same ```retain``` and ```release``` functions as the base type. No additional annotation is required on the derived types.
+When a C++ type inherits from a `SWIFT_SHARED_REFERENCE` base type, the Swift compiler automatically infers `SWIFT_SHARED_REFERENCE` annotation for the derived type.
+The derived type also gets imported as a reference type, and uses the same `retain` and `release` functions as its base class.
 
 ### Inheritance and Virtual Member Functions
 

--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -1256,7 +1256,8 @@ object.doSomething()
 ```
 
 ### Inference for Derived Types
-Swift compiler automatically infers the ```SWIFT_SHARED_REFERENCE``` annotation for C++ types that inherit from a base type annotated with ```SWIFT_SHARED_REFERENCE```. These derived types are imported as Swift reference types or Swift class types that use the same ```retain``` and ```release``` functions as the base type. No additional annotation is required on the derived types.
+
+Swift compiler automatically infers the ```SWIFT_SHARED_REFERENCE``` annotation for C++ types that inherit from a base type annotated with ```SWIFT_SHARED_REFERENCE```. These derived types are also imported as a reference type in Swift that use the same ```retain``` and ```release``` functions as the base type. No additional annotation is required on the derived types.
 
 ### Inheritance and Virtual Member Functions
 

--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -1259,6 +1259,12 @@ object.doSomething()
 
 When a C++ type inherits from a `SWIFT_SHARED_REFERENCE` base type, the Swift compiler automatically infers `SWIFT_SHARED_REFERENCE` annotation for the derived type.
 The derived type also gets imported as a reference type, and uses the same `retain` and `release` functions as its base class.
+This inference works as long as all the annotated base types in the inheritance chain (including multiple or indirect inheritance) have the same `retain` and `release` functions.
+If multiple base types have conflicting `retain` or `release` functions, the derived type is imported as a Swift value type, and the compiler emits a warning.
+
+
+Note that this inference currently applies only to `SWIFT_SHARED_REFERENCE`. 
+It does not apply to types annotated with `SWIFT_IMMORTAL_REFERENCE` or `SWIFT_UNSAFE_REFERENCE`.
 
 ### Inheritance and Virtual Member Functions
 


### PR DESCRIPTION
Adding a sentence in the documentation thatthe  foreign-reference annotations are now propagated to inherited C++ types