### PR TITLE
Fix linux install command

### DIFF
--- a/_data/new-data/install/linux/releases.yml
+++ b/_data/new-data/install/linux/releases.yml
@@ -9,7 +9,7 @@ latest-release:
           curl -O https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz && \
           tar zxf swiftly-$(uname -m).tar.gz && \
           ./swiftly init --quiet-shell-followup && \
-          . "${SWIFTLY_HOME_DIR:-~/.local/share/swiftly}/env.sh" && \
+          . "${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}/env.sh" && \
           hash -r
       - label: Fish
         code: |-

--- a/_data/new-data/install/macos/releases.yml
+++ b/_data/new-data/install/macos/releases.yml
@@ -9,7 +9,7 @@ latest-release:
           curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg && \
           installer -pkg swiftly.pkg -target CurrentUserHomeDirectory && \
           ~/.swiftly/bin/swiftly init --quiet-shell-followup && \
-          . "${SWIFTLY_HOME_DIR:-~/.swiftly}/env.sh" && \
+          . "${SWIFTLY_HOME_DIR:-$HOME/.swiftly}/env.sh" && \
           hash -r
       - label: Fish
         code: |

--- a/_includes/install/_linux_platforms_tabs.md
+++ b/_includes/install/_linux_platforms_tabs.md
@@ -9,7 +9,7 @@
   <div class="language-plaintext highlighter-rouge"><div class="highlight"><button>Copy</button><pre class="highlight"><code>curl -O "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz" &amp;&amp; \
 tar zxf "swiftly-$(uname -m).tar.gz" &amp;&amp; \
 ./swiftly init --quiet-shell-followup &amp;&amp; \
-. ${SWIFTLY_HOME_DIR:-~/.local/share/swiftly}/env.sh &amp;&amp; \
+. ${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}/env.sh &amp;&amp; \
 hash -r
 </code></pre></div></div>
   <h4>License: <a href="https://raw.githubusercontent.com/swiftlang/swiftly/refs/heads/main/LICENSE.txt">Apache-2.0</a> | PGP: <a href="https://download.swift.org/swiftly/linux/swiftly-0.4.0-dev-x86_64.tar.gz.sig">Signature</a></h4>


### PR DESCRIPTION
I'm getting an error running the swiftly install command in a  docker container (ubuntu:jammy, although I don't think that matters):

```
$ curl -O https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz && \
tar zxf swiftly-$(uname -m).tar.gz && \
./swiftly init --quiet-shell-followup && \
. "${SWIFTLY_HOME_DIR:-~/.local/share/swiftly}/env.sh" && \
hash -r
...
The global default toolchain has been set to `Swift 6.1.2`
Swift 6.1.2 installed successfully!
/bin/sh: 1: .: cannot open ~/.local/share/swiftly/env.sh: No such file
```

I believe the tail end of the install command should be
```
. "${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}/env.sh"
```
to avoid that error.
