### PR TITLE
Fix quoted home in swiftly install snippets

### DIFF
--- a/_data/new-data/install/linux/releases.yml
+++ b/_data/new-data/install/linux/releases.yml
@@ -9,7 +9,7 @@ latest-release:
           curl -O https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz && \
           tar zxf swiftly-$(uname -m).tar.gz && \
           ./swiftly init --quiet-shell-followup && \
-          . "${SWIFTLY_HOME_DIR:-~/.local/share/swiftly}/env.sh" && \
+          . "${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}/env.sh" && \
           hash -r
       - label: Fish
         code: |-

--- a/_data/new-data/install/macos/releases.yml
+++ b/_data/new-data/install/macos/releases.yml
@@ -9,7 +9,7 @@ latest-release:
           curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg && \
           installer -pkg swiftly.pkg -target CurrentUserHomeDirectory && \
           ~/.swiftly/bin/swiftly init --quiet-shell-followup && \
-          . "${SWIFTLY_HOME_DIR:-~/.swiftly}/env.sh" && \
+          . "${SWIFTLY_HOME_DIR:-$HOME/.swiftly}/env.sh" && \
           hash -r
       - label: Fish
         code: |


### PR DESCRIPTION
The swiftly install snippets with the new website design are quoting the source of the `env.sh`
script. Inside, there is a `~` character that represents the home directory. Since it is inside
quotes this is not interpreted by the shell. It fails to find a directory called `~` in the current
directory and swiftly isn't added to the PATH. The subsequent rehash is never run either.

### Motivation:

Let's improve the initial user experience by fixing the failure.

### Modifications:

Use the `$HOME` environment variable inside the quoted string instead of `~` so that it gets interpolated.

### Result:

The instructions should be runnable by new users again.
