### PR TITLE
Added compatibility information for Wasm and Android to all packages

### DIFF
--- a/_data/packages/packages.yml
+++ b/_data/packages/packages.yml
@@ -30,7 +30,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS) and Linux
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS), Linux, and Android
         license: Apache 2.0
         url: https://swiftpackageindex.com/perrystreetsoftware/Harmonize
         note: Discussed on [Episode 57 of Swift Package Indexing](https://share.transistor.fm/s/32b618c5){:target='_blank'}.
@@ -42,8 +43,10 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
+          - Wasm
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
+          Wasm, and Android
         license: MIT
         url: https://swiftpackageindex.com/southkin/HasLazyServer
         note: Discussed on [Episode 56 of Swift Package Indexing](https://share.transistor.fm/s/135e7db3){:target='_blank'}.
@@ -102,10 +105,25 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
+          - Wasm
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
+          and Wasm
         license: Apache 2.0
         url: https://swiftpackageindex.com/swiftlang/swift-testing
+      - name: swift-dependencies
+        description: A dependency management library for controlling and overriding dependencies
+          in Swift applications. Helps with testing, SwiftUI previews, and compile-time
+          performance.
+        owner: Point-Free
+        swift_compatibility: 5.9+
+        platform_compatibility:
+          - Apple
+          - Linux
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
+          and Android
+        license: MIT
+        url: https://swiftpackageindex.com/pointfreeco/swift-dependencies
       - name: Defaults
         description: Defaults is a type-safe wrapper around UserDefaults and supports
           Codable, NSSecureCoding, change observation, and SwiftUI integration. It offers
@@ -117,19 +135,6 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
         license: MIT
         url: https://swiftpackageindex.com/sindresorhus/Defaults
-      - name: swift-dependencies
-        description: A dependency management library for controlling and overriding dependencies
-          in Swift applications. Helps with testing, SwiftUI previews, and compile-time
-          performance.
-        owner: Point-Free
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: MIT
-        url: https://swiftpackageindex.com/pointfreeco/swift-dependencies
       - name: swift-case-paths
         description: CasePaths extends the functionality of key paths to enum cases, allowing
           for the extraction, modification, and testing of associated values in enums.
@@ -138,8 +143,10 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
+          - Wasm
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
+          Wasm, and Android
         license: MIT
         url: https://swiftpackageindex.com/pointfreeco/swift-case-paths
   - name: Server
@@ -161,8 +168,9 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
+          and Android
         license: MIT
         url: https://swiftpackageindex.com/vapor/vapor
       - name: swift-openapi-generator
@@ -173,7 +181,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (macOS) and Linux
+          - Android
+        platform_compatibility_tooltip: Apple (macOS), Linux, and Android
         license: Apache 2.0
         url: https://swiftpackageindex.com/apple/swift-openapi-generator
       - name: hummingbird
@@ -185,7 +194,9 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS) and Linux
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS), Linux, and
+          Android
         license: Apache 2.0
         url: https://swiftpackageindex.com/hummingbird-project/hummingbird
       - name: MongoKitten
@@ -208,8 +219,9 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
+          and Android
         license: MIT
         url: https://swiftpackageindex.com/vapor/fluent
       - name: multipart-kit
@@ -221,8 +233,10 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
+          - Wasm
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
+          Wasm, and Android
         license: MIT
         url: https://swiftpackageindex.com/vapor/multipart-kit
   - name: Networking
@@ -245,8 +259,9 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
+          and Android
         license: MIT
         url: https://swiftpackageindex.com/Alamofire/Alamofire
       - name: swift-nio
@@ -258,21 +273,11 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
+          and Android
         license: Apache 2.0
         url: https://swiftpackageindex.com/apple/swift-nio
-      - name: Pulse
-        description: Pulse is a powerful logging system for Apple platforms. It records
-          and inspects logs and network requests, and allows for real-time viewing and
-          sharing.
-        owner: Alex Grebenyuk
-        swift_compatibility: 5.10+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-        license: MIT
-        url: https://swiftpackageindex.com/kean/Pulse
       - name: FlyingFox
         description: FlyingFox enables the creation of lightweight, concurrent HTTP servers
           with support for WebSockets and static file serving. It uses non blocking BSD
@@ -282,8 +287,9 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
+          and Android
         license: MIT
         url: https://swiftpackageindex.com/swhitty/FlyingFox
       - name: Moya
@@ -296,17 +302,30 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
         license: MIT
         url: https://swiftpackageindex.com/Moya/Moya
-      - name: Networking
-        description: Networking is a Swift library for making network requests with a
-          straightforward API. It supports faking requests, caching images, and various
-          types of authentication.
-        owner: Elvis Nunez
-        swift_compatibility: 5.9+
+      - name: Pulse
+        description: Pulse is a powerful logging system for Apple platforms. It records
+          and inspects logs and network requests, and allows for real-time viewing and
+          sharing.
+        owner: Alex Grebenyuk
+        swift_compatibility: 5.10+
         platform_compatibility:
           - Apple
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
         license: MIT
-        url: https://swiftpackageindex.com/3lvis/Networking
+        url: https://swiftpackageindex.com/kean/Pulse
+      - name: ProtocolBuffers
+        description: Swift implementation of Protocol Buffers for encoding structured
+          data in an efficient, extensible format. Supports Protocol Buffers 3.0 features,
+          including serialization, deserialization, and JSON conversion.
+        owner: Alexey Khokhlov
+        swift_compatibility: 5.9+
+        platform_compatibility:
+          - Linux
+          - Wasm
+          - Android
+        platform_compatibility_tooltip: Linux, Wasm, and Android
+        license: Apache 2.0
+        url: https://swiftpackageindex.com/alexeyxo/protobuf-swift
   - name: Testing
     slug: testing
     brief: "If you want to level up your project\u2019s tests, take a look at a selection
@@ -326,8 +345,9 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
+          - Wasm
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
+          and Wasm
         license: Apache 2.0
         url: https://swiftpackageindex.com/swiftlang/swift-testing
       - name: swift-snapshot-testing
@@ -340,8 +360,9 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
+          and Android
         license: MIT
         url: https://swiftpackageindex.com/pointfreeco/swift-snapshot-testing
       - name: swift-custom-dump
@@ -353,8 +374,10 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
+          - Wasm
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
+          Wasm, and Android
         license: MIT
         url: https://swiftpackageindex.com/pointfreeco/swift-custom-dump
       - name: Quick
@@ -366,7 +389,9 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS) and Linux
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS), Linux, and
+          Android
         license: Apache 2.0
         url: https://swiftpackageindex.com/Quick/Quick
       - name: OCMockito
@@ -410,8 +435,10 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
+          - Wasm
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
+          Wasm, and Android
         license: Apache 2.0
         url: https://swiftpackageindex.com/apple/swift-log
       - name: Datadog
@@ -435,17 +462,6 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
         license: BSD 3-Clause
         url: https://swiftpackageindex.com/CocoaLumberjack/CocoaLumberjack
-      - name: Pulse
-        description: Pulse is a powerful logging system for Apple platforms. It records
-          and inspects logs and network requests, and allows for real-time viewing and
-          sharing.
-        owner: Alex Grebenyuk
-        swift_compatibility: 5.10+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-        license: MIT
-        url: https://swiftpackageindex.com/kean/Pulse
       - name: SwiftyBeaver
         description: SwiftyBeaver is a flexible, colorful, lightweight logging library
           for Swift. It supports console, file, and cloud destinations and is ideal for
@@ -458,6 +474,17 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS, watchOS, tvOS) and Linux
         license: MIT
         url: https://swiftpackageindex.com/SwiftyBeaver/SwiftyBeaver
+      - name: Pulse
+        description: Pulse is a powerful logging system for Apple platforms. It records
+          and inspects logs and network requests, and allows for real-time viewing and
+          sharing.
+        owner: Alex Grebenyuk
+        swift_compatibility: 5.10+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+        license: MIT
+        url: https://swiftpackageindex.com/kean/Pulse
       - name: Wormholy
         description: Wormholy is a debugging tool for iOS network calls. It records app
           traffic, reveals request and response content, and helps with debugging and
@@ -490,6 +517,17 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS, watchOS, tvOS) and Linux
         license: MIT
         url: https://swiftpackageindex.com/groue/GRDB.swift
+      - name: Firebase
+        description: Firebase provides app development tools including authentication,
+          database, cloud messaging, analytics, and storage for building, growing, and
+          monetizing mobile applications.
+        owner: Firebase
+        swift_compatibility: 6.0+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, macOS, tvOS)
+        license: Apache 2.0
+        url: https://swiftpackageindex.com/firebase/firebase-ios-sdk
       - name: Supabase
         description: Supabase client for Swift, mirroring the design of supabase-js, offering
           database interaction, authentication, storage, and real-time capabilities. Supports
@@ -499,8 +537,9 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
+          and Android
         license: MIT
         url: https://swiftpackageindex.com/supabase/supabase-swift
       - name: MongoKitten
@@ -515,18 +554,6 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS) and Linux
         license: MIT
         url: https://swiftpackageindex.com/orlandos-nl/MongoKitten
-      - name: fluent
-        description: Fluent helps you work with databases, providing a high-level, type-safe
-          API for querying and manipulating data in Vapor apps.
-        owner: Vapor
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: MIT
-        url: https://swiftpackageindex.com/vapor/fluent
       - name: Realm
         description: Realm is a mobile database for iOS, macOS, tvOS, and watchOS. It
           offers an object-oriented data model, real-time syncing, and encryption. It
@@ -538,14 +565,16 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
         license: Apache 2.0
         url: https://swiftpackageindex.com/realm/realm-swift
-      - name: Boutique
-        description: Boutique simplifies state-driven app development with a dual-layered
-          memory and disk caching system, offering easy persistence and real-time updates
-          for SwiftUI, UIKit, and AppKit applications.
-        owner: Joe Fabisevich
-        swift_compatibility: 5.10+
+      - name: fluent
+        description: Fluent helps you work with databases, providing a high-level, type-safe
+          API for querying and manipulating data in Vapor apps.
+        owner: Vapor
+        swift_compatibility: 5.9+
         platform_compatibility:
           - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS)
+          - Linux
+          - Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
+          and Android
         license: MIT
-        url: https://swiftpackageindex.com/mergesort/Boutique
+        url: https://swiftpackageindex.com/vapor/fluent

--- a/_data/packages/showcase-history.yml
+++ b/_data/packages/showcase-history.yml
@@ -64,8 +64,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, and Android
             license: Apache 2.0
             url: https://swiftpackageindex.com/grpc/grpc-swift
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/127){:target='_blank'}.
@@ -145,7 +146,7 @@ years:
             swift_compatibility: 6.0+
             platform_compatibility:
               - Apple
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+            platform_compatibility_tooltip: Apple (macOS, watchOS, tvOS)
             license: MIT
             url: https://swiftpackageindex.com/wigging/numerix
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/119){:target='_blank'}.
@@ -158,7 +159,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS) and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS), Linux, and
+              Android
             license: Apache 2.0
             url: https://swiftpackageindex.com/adam-fowler/swift-zip-archive
             note: Discussed on [Episode 53 of Swift Package Indexing](https://share.transistor.fm/s/56a29e9f){:target='_blank'}.
@@ -187,8 +190,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, and Android
             license: MIT
             url: https://swiftpackageindex.com/drewmccormack/Forked
             note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/119){:target='_blank'}.
@@ -201,8 +205,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, and Android
             license: MIT
             url: https://swiftpackageindex.com/alessiorubicini/SwiftSessions
             note: Discussed on [Episode 46 of Swift Package Indexing](https://share.transistor.fm/s/08c0a3f9){:target='_blank'}.
@@ -254,8 +259,10 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, Wasm, and Android
             license: BSD 3-Clause
             url: https://swiftpackageindex.com/mattmassicotte/Queue
             note: Discussed on [Episode 52 of Swift Package Indexing](https://share.transistor.fm/s/687d1170){:target='_blank'}.
@@ -293,8 +300,10 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, Wasm, and Android
             license: Apache 2.0
             url: https://swiftpackageindex.com/hummingbird-project/swift-mustache
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/107){:target='_blank'}.
@@ -349,7 +358,10 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS) and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS), Linux, Wasm, and
+              Android
             license: MIT
             url: https://swiftpackageindex.com/peterringset/JSONPatch
             note: Discussed on [Episode 51 of Swift Package Indexing](https://share.transistor.fm/s/257bd1fa){:target='_blank'}.
@@ -362,8 +374,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, and Android
             license: MIT
             url: https://swiftpackageindex.com/pointfreeco/swift-issue-reporting
             note: Linked to in [Issue 671 of iOS Dev Weekly](https://iosdevweekly.com/issues/671#gpHvv6S){:target='_blank'}.
@@ -377,8 +390,10 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, Wasm, and Android
             license: MIT
             url: https://swiftpackageindex.com/ladvoc/BijectiveDictionary
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/90){:target='_blank'}.
@@ -391,8 +406,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, and Android
             license: MIT
             url: https://swiftpackageindex.com/GeorgeLyon/SwiftClaude
             note: Discussed on [Episode 51 of Swift Package Indexing](https://share.transistor.fm/s/257bd1fa){:target='_blank'}.
@@ -420,8 +436,10 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, Wasm, and Android
             license: Apache 2.0
             url: https://swiftpackageindex.com/apple/swift-crypto
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/93){:target='_blank'}.
@@ -460,8 +478,10 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, Wasm, and Android
             license: MIT
             url: https://swiftpackageindex.com/mtj0928/swift-async-operations
             note: Discussed on [Episode 50 of Swift Package Indexing](https://share.transistor.fm/s/333d2750){:target='_blank'}.
@@ -486,8 +506,10 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, Wasm, and Android
             license: MIT
             url: https://swiftpackageindex.com/tevelee/swift-graphs
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/91){:target='_blank'}.
@@ -515,8 +537,10 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, Wasm, and Android
             license: Apache 2.0
             url: https://swiftpackageindex.com/sliemeobn/elementary
             note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/82){:target='_blank'}.
@@ -528,7 +552,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (macOS) and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (macOS), Linux, and Android
             license: Apache 2.0
             url: https://swiftpackageindex.com/apple/swift-openapi-generator
             note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/84){:target='_blank'}.
@@ -541,7 +566,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (macOS) and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (macOS), Linux, and Android
             license: MIT
             url: https://swiftpackageindex.com/franklefebvre/swift-export
             note: Linked to in [Issue 679 of iOS Dev Weekly](https://iosdevweekly.com/issues/679#DXo4Uf9){:target='_blank'}.
@@ -581,8 +607,10 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, Wasm, and Android
             license: MIT
             url: https://swiftpackageindex.com/davbeck/swift-glob
             note: Discussed on [Episode 44 of Swift Package Indexing](https://share.transistor.fm/s/cbb0c6ad){:target='_blank'}.
@@ -660,8 +688,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, and Android
             license: Apache 2.0
             url: https://swiftpackageindex.com/DiscordBM/DiscordBM
             note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/74){:target='_blank'}.
@@ -673,7 +702,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (macOS, visionOS), Linux, Wasm, and Android
             license: MIT
             url: https://swiftpackageindex.com/giginet/swift-testing-revolutionary
             note: Discussed on [Episode 46 of Swift Package Indexing](https://share.transistor.fm/s/08c0a3f9){:target='_blank'}.
@@ -721,8 +752,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Wasm
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, and Wasm
             license: Apache 2.0
             url: https://swiftpackageindex.com/tayloraswift/swift-dom
             note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/66){:target='_blank'}.
@@ -738,7 +770,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS) and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS), Linux, and
+              Android
             license: Apache 2.0
             url: https://swiftpackageindex.com/hummingbird-project/hummingbird
             note: Discussed on [Episode 45 of Swift Package Indexing](https://share.transistor.fm/s/53ee9157){:target='_blank'}.
@@ -774,7 +808,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (macOS, visionOS), Linux, and Android
             license: MIT
             url: https://swiftpackageindex.com/m-barthelemy/AcmeSwift
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/63){:target='_blank'}.
@@ -798,8 +833,10 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, Wasm, and Android
             license: MIT
             url: https://swiftpackageindex.com/mochidev/CodableDatastore
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/63){:target='_blank'}.
@@ -815,8 +852,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, and Android
             license: Apache 2.0
             url: https://swiftpackageindex.com/funcmike/rabbitmq-nio
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/48){:target='_blank'}.
@@ -828,8 +866,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, and Android
             license: MIT
             url: https://swiftpackageindex.com/mattcox/Pack
             note: Discussed on [Episode 43 of Swift Package Indexing](https://share.transistor.fm/s/2d4b1ba7){:target='_blank'}.
@@ -854,8 +893,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, and Android
             license: MIT
             url: https://swiftpackageindex.com/swiftwasm/WasmKit
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/53){:target='_blank'}.
@@ -915,8 +955,10 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, Wasm, and Android
             license: The Unlicense
             url: https://swiftpackageindex.com/designedbyclowns/GeoURI
             note: Discussed on [Episode 43 of Swift Package Indexing](https://share.transistor.fm/s/2d4b1ba7){:target='_blank'}.
@@ -928,8 +970,10 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, Wasm, and Android
             license: MIT
             url: https://swiftpackageindex.com/pointfreeco/swift-perception
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/24){:target='_blank'}.
@@ -941,7 +985,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (macOS, visionOS), Linux, and Android
             license: MIT
             url: https://swiftpackageindex.com/gh123man/Async-Channels
             note: Discussed on [Episode 42 of Swift Package Indexing](https://share.transistor.fm/s/c118cc9c){:target='_blank'}.
@@ -953,8 +998,10 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, Wasm, and Android
             license: MIT
             url: https://swiftpackageindex.com/jonreid/ExpectToEventuallyEqual
             note: Discussed on [Episode 41 of Swift Package Indexing](https://share.transistor.fm/s/861890bb){:target='_blank'}.
@@ -994,8 +1041,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, and Android
             license: MIT
             url: https://swiftpackageindex.com/swhitty/FlyingFox
             note: Discussed on [Episode 41 of Swift Package Indexing](https://share.transistor.fm/s/861890bb){:target='_blank'}.
@@ -1047,8 +1095,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, and Android
             license: MIT
             url: https://swiftpackageindex.com/davedelong/time
             note:
@@ -1063,8 +1112,10 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, Wasm, and Android
             license: MIT
             url: https://swiftpackageindex.com/0xLeif/Fork
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/29){:target='_blank'}.
@@ -1117,8 +1168,10 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, Wasm, and Android
             license: MIT
             url: https://swiftpackageindex.com/jrothwell/VersionedCodable
             note: Discussed on [Episode 40 of Swift Package Indexing](https://share.transistor.fm/s/a452cfcd){:target='_blank'}.
@@ -1219,8 +1272,10 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Wasm
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, Wasm, and Android
             license: MIT
             url: https://swiftpackageindex.com/mattpolzin/OpenAPIKit
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/12){:target='_blank'}.
@@ -1246,8 +1301,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, and Android
             license: MIT
             url: https://swiftpackageindex.com/space-code/typhoon
             note: Discussed on [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}.
@@ -1289,8 +1345,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, and Android
             license: MIT
             url: https://swiftpackageindex.com/davedelong/time
             note: Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/7){:target='_blank'}.
@@ -1310,8 +1367,9 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-              and Linux
+              - Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
+              Linux, and Android
             license: MIT
             url: https://swiftpackageindex.com/gohanlon/swift-memberwise-init-macro
             note: Discussed in [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}.
@@ -1379,7 +1437,8 @@ years:
             swift_compatibility: 5.9+
             platform_compatibility:
               - Apple
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS)
+              - Wasm
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS) and Wasm
             license: MIT
             url: https://swiftpackageindex.com/automerge/automerge-swift
             note: Discussed on [Episode 36 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/36-even-though-the-bug-is-fixed-its-not-over){:target='_blank'}.


### PR DESCRIPTION
### Motivation:

The Swift Package Index recently added Wasm and Android compatibility testing. This PR, and the corresponding changes to the [PackageListTool](https://github.com/SwiftPackageIndex/PackageListTool) automate the addition of this data into the Swift.org package listings.

### Modifications:

Adds Wasm and Android to package "cards" that are compatible with those platforms.

### Result:

The screenshot shows a variety of platform compatibilities, including one with all four that we can test for.

![Screenshot 2025-06-16 at 18 03 49@2x](https://github.com/user-attachments/assets/a2623897-3680-4ec7-96a0-6f718f9b7f32)

