### PR TITLE
Remove `-c release` requirement from `wasm-getting-started.md`

### DIFF
--- a/documentation/articles/wasm-getting-started.md
+++ b/documentation/articles/wasm-getting-started.md
@@ -99,6 +99,5 @@ Hello from WASI!
 allowing the toolchain to produce Wasm binaries that are multiple orders of magnitude smaller. One of the Swift SDKs in the artifact bundle you've installed
 with the `swift sdk install` command is tailored specifically for Embedded Swift.
 
-To build with Embedded Swift SDK, pass its ID as noted in `swift sdk list` output (which has an `-embedded` suffix) in the `--swift-sdk` option. You also have to pass `-c release`
-to `swift build` and `swift run` to enable optimizations required for Embedded Swift.
+To build with Embedded Swift SDK, pass its ID as noted in `swift sdk list` output (which has an `-embedded` suffix) in the `--swift-sdk` option.
 


### PR DESCRIPTION

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

As of `swift-6.2-DEVELOPMENT-SNAPSHOT-2025-06-26-a` passing this option is no longer required for Embedded Swift.

### Modifications:

Remove a sentence requiring use of `-c release` for Embedded Swift.

### Result:

Instructions are more clear and easier to follow.