### PR TITLE
Fix static-sdk JSON 6.2 API

### DIFF
--- a/api/v1/install/dev/6.2/static-sdk.json
+++ b/api/v1/install/dev/6.2/static-sdk.json
@@ -1,4 +1,4 @@
 ---
 layout: none
 ---
-{{ site.data.builds.swift-6_2-branch.static_sdk | jsonify }}
+{{ site.data.builds.swift-6_2-branch.static-sdk | jsonify }}

--- a/openapi/swiftorg.yaml
+++ b/openapi/swiftorg.yaml
@@ -232,6 +232,8 @@ components:
       enum:
         - main
         - '6.0'
+        - '6.1'
+        - '6.2'
     SourceBranch:
       anyOf:
         - $ref: '#/components/schemas/KnownSourceBranch'


### PR DESCRIPTION
Fix static-sdk JSON API for 6.2 branch

### Motivation:

- [Static SDKs JSON API](https://www.swift.org/api/v1/install/dev/6.2/static-sdk.json) returns `null` for 6.2 branch.
- OpenAPI spec doesn't include branch 6.2 so tests don't catch this.

### Modifications:

- Fixed the yaml data source path of the JSON API.
- Added branches 6.1, 6.2 to OpenAPI spec.

### Result:

- `/api/v1/install/dev/6.2/static-sdk.json` returns a valid value.
- [Local test](https://github.com/swiftlang/swift-org-website/tree/main/openapi/TestSwiftOrgClient#usage) now also tests branches 6.1, 6.2 and passes.
