### PR TITLE
adds 'heckj' to reviewers sets to be able to review pull requests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,7 +29,7 @@
 CODEOWNERS @timsneath @tkremenek @shahmishal @davelester
 /index.md @timsneath @tkremenek @shahmishal @davelester
 /_data/new-data/landing/* @timsneath @tkremenek @shahmishal @davelester
-/_posts/* @timsneath @tkremenek @shahmishal @davelester @heckj
+/_posts/* @timsneath @tkremenek @shahmishal @davelester
 
 /gsoc*/ @ktoso
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,13 +24,13 @@
 
 # The following lines are used by GitHub to automatically recommend reviewers.
 
-* @0xTim @alexandersandberg @davelester @daveverwer @dempseyatgithub @kaishin @shahmishal @timsneath @federicobucchi
+* @0xTim @alexandersandberg @davelester @daveverwer @dempseyatgithub @kaishin @shahmishal @timsneath @federicobucchi @heckj
 
 CODEOWNERS @timsneath @tkremenek @shahmishal @davelester
 /index.md @timsneath @tkremenek @shahmishal @davelester
 /_data/new-data/landing/* @timsneath @tkremenek @shahmishal @davelester
-/_posts/* @timsneath @tkremenek @shahmishal @davelester
+/_posts/* @timsneath @tkremenek @shahmishal @davelester @heckj
 
 /gsoc*/ @ktoso
 
-/openapi/ @czechboy0
+/openapi/ @czechboy0 @heckj


### PR DESCRIPTION
Add 'heckj' to reviewers for pull requests

### Motivation:

Having joined the workgroup, adding my GitHub handle to be able to provide reviews for existing pull requests.

### Modifications:

Updated CODEOWNERS 

### Result:

Will be able to provide reviews for pull requests
