### PR TITLE
Fix "Copy install command" button on old releases page

### DIFF
--- a/_includes/install/_old-release.html
+++ b/_includes/install/_old-release.html
@@ -50,12 +50,7 @@
         {% assign static_sdk = release_info.platforms | where: 'name', 'Static SDK'| first %}
     {% if static_sdk %}
         {% assign tag_downcase = include.release.tag | downcase %}
-        <button onclick="copyToClipboard('swift sdk install https://download.swift.org/{{ tag_downcase }}/static-sdk/{{ include.release.tag }}/{{ include.release.tag }}_static-linux-0.0.1.artifactbundle.tar.gz --checksum {{ static_sdk.checksum }}')">Copy install command</button>
-    <script>
-        function copyToClipboard(text) {
-          navigator.clipboard.writeText(text)
-        }
-    </script>
+        <button onclick="copyToClipboard(this, 'swift sdk install https://download.swift.org/{{ tag_downcase }}/static-sdk/{{ include.release.tag }}/{{ include.release.tag }}_static-linux-0.0.1.artifactbundle.tar.gz --checksum {{ static_sdk.checksum }}')">Copy install command</button>
     {% else %}
         Unavailable
     {% endif %}


### PR DESCRIPTION
There are two definitions of `copyToClipboard` in the codebase, one with one arg
and one with two args. The onClick handler ends up calling the wrong one for a
number of links. I assume the issue is something like:
- Both definitions end up being defined on the same page
- The onClick ends up getting the one with two args when it expects the one with one arg.

Attempt to fix this by instead using the two arg version and removing the one arg version.
However I do not have a Ruby environment setup to test with so I haven't been able to try it.

This resolves https://github.com/swiftlang/swift-org-website/issues/1108.