### PR TITLE
Fixed up package compatibility to only focus on supported platforms

### DIFF
--- a/_data/packages/packages.yml
+++ b/_data/packages/packages.yml
@@ -30,8 +30,7 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS), Linux, and Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS) and Linux
         license: Apache 2.0
         url: https://swiftpackageindex.com/perrystreetsoftware/Harmonize
         note: Discussed on [Episode 57 of Swift Package Indexing](https://share.transistor.fm/s/32b618c5){:target='_blank'}.
@@ -43,10 +42,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Wasm
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
-          Wasm, and Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: MIT
         url: https://swiftpackageindex.com/southkin/HasLazyServer
         note: Discussed on [Episode 56 of Swift Package Indexing](https://share.transistor.fm/s/135e7db3){:target='_blank'}.
@@ -105,9 +102,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Wasm
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
-          and Wasm
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: Apache 2.0
         url: https://swiftpackageindex.com/swiftlang/swift-testing
       - name: Defaults
@@ -129,10 +125,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Wasm
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
-          Wasm, and Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: MIT
         url: https://swiftpackageindex.com/pointfreeco/swift-case-paths
       - name: swift-perception
@@ -143,10 +137,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Wasm
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
-          Wasm, and Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: MIT
         url: https://swiftpackageindex.com/pointfreeco/swift-perception
   - name: Server
@@ -168,9 +160,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
-          and Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: MIT
         url: https://swiftpackageindex.com/vapor/vapor
       - name: swift-openapi-generator
@@ -181,8 +172,7 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Android
-        platform_compatibility_tooltip: Apple (macOS), Linux, and Android
+        platform_compatibility_tooltip: Apple (macOS) and Linux
         license: Apache 2.0
         url: https://swiftpackageindex.com/apple/swift-openapi-generator
       - name: hummingbird
@@ -194,9 +184,7 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS), Linux, and
-          Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS) and Linux
         license: Apache 2.0
         url: https://swiftpackageindex.com/hummingbird-project/hummingbird
       - name: fluent
@@ -207,9 +195,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
-          and Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: MIT
         url: https://swiftpackageindex.com/vapor/fluent
       - name: console-kit
@@ -221,9 +208,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
-          and Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: MIT
         url: https://swiftpackageindex.com/vapor/console-kit
       - name: MongoKitten
@@ -258,9 +244,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
-          and Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: MIT
         url: https://swiftpackageindex.com/Alamofire/Alamofire
       - name: swift-nio
@@ -272,9 +257,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
-          and Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: Apache 2.0
         url: https://swiftpackageindex.com/apple/swift-nio
       - name: Pulse
@@ -297,9 +281,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
-          and Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: MIT
         url: https://swiftpackageindex.com/swhitty/FlyingFox
       - name: Moya
@@ -343,9 +326,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Wasm
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
-          and Wasm
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: Apache 2.0
         url: https://swiftpackageindex.com/swiftlang/swift-testing
       - name: swift-snapshot-testing
@@ -358,9 +340,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
-          and Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: MIT
         url: https://swiftpackageindex.com/pointfreeco/swift-snapshot-testing
       - name: swift-custom-dump
@@ -372,10 +353,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Wasm
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
-          Wasm, and Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: MIT
         url: https://swiftpackageindex.com/pointfreeco/swift-custom-dump
       - name: Quick
@@ -387,9 +366,7 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS), Linux, and
-          Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS) and Linux
         license: Apache 2.0
         url: https://swiftpackageindex.com/Quick/Quick
       - name: OCMockito
@@ -433,10 +410,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Wasm
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
-          Wasm, and Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: Apache 2.0
         url: https://swiftpackageindex.com/apple/swift-log
       - name: CocoaLumberjack
@@ -516,9 +491,9 @@ categories:
         license: MIT
         url: https://swiftpackageindex.com/groue/GRDB.swift
       - name: Firebase
-        description: Firebase provides app development tools including authentication,
-          database, cloud messaging, analytics, and storage for building, growing, and
-          monetizing mobile applications.
+        description: Firebase offers a suite of development tools for building, growing,
+          and monetizing applications across Apple platforms, excluding FirebaseAnalytics.
+          It supports various components like Auth, Database, and Performance Monitoring.
         owner: Firebase
         swift_compatibility: 6.0+
         platform_compatibility:
@@ -534,9 +509,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
-          and Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: MIT
         url: https://swiftpackageindex.com/vapor/fluent
       - name: Supabase
@@ -548,9 +522,8 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-          - Android
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS), Linux,
-          and Android
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
         license: MIT
         url: https://swiftpackageindex.com/supabase/supabase-swift
       - name: Realm

--- a/_data/packages/showcase-history.yml
+++ b/_data/packages/showcase-history.yml
@@ -64,9 +64,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: Apache 2.0
             url: https://swiftpackageindex.com/grpc/grpc-swift
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/127){:target='_blank'}.
@@ -159,9 +158,7 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS), Linux, and
-              Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS) and Linux
             license: Apache 2.0
             url: https://swiftpackageindex.com/adam-fowler/swift-zip-archive
             note: Discussed on [Episode 53 of Swift Package Indexing](https://share.transistor.fm/s/56a29e9f){:target='_blank'}.
@@ -190,9 +187,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/drewmccormack/Forked
             note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/119){:target='_blank'}.
@@ -205,9 +201,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/alessiorubicini/SwiftSessions
             note: Discussed on [Episode 46 of Swift Package Indexing](https://share.transistor.fm/s/08c0a3f9){:target='_blank'}.
@@ -259,10 +254,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, Wasm, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: BSD 3-Clause
             url: https://swiftpackageindex.com/mattmassicotte/Queue
             note: Discussed on [Episode 52 of Swift Package Indexing](https://share.transistor.fm/s/687d1170){:target='_blank'}.
@@ -300,10 +293,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, Wasm, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: Apache 2.0
             url: https://swiftpackageindex.com/hummingbird-project/swift-mustache
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/107){:target='_blank'}.
@@ -358,10 +349,7 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS), Linux, Wasm, and
-              Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS) and Linux
             license: MIT
             url: https://swiftpackageindex.com/peterringset/JSONPatch
             note: Discussed on [Episode 51 of Swift Package Indexing](https://share.transistor.fm/s/257bd1fa){:target='_blank'}.
@@ -374,9 +362,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/pointfreeco/swift-issue-reporting
             note: Linked to in [Issue 671 of iOS Dev Weekly](https://iosdevweekly.com/issues/671#gpHvv6S){:target='_blank'}.
@@ -390,10 +377,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, Wasm, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/ladvoc/BijectiveDictionary
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/90){:target='_blank'}.
@@ -406,9 +391,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/GeorgeLyon/SwiftClaude
             note: Discussed on [Episode 51 of Swift Package Indexing](https://share.transistor.fm/s/257bd1fa){:target='_blank'}.
@@ -436,10 +420,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, Wasm, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: Apache 2.0
             url: https://swiftpackageindex.com/apple/swift-crypto
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/93){:target='_blank'}.
@@ -478,10 +460,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, Wasm, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/mtj0928/swift-async-operations
             note: Discussed on [Episode 50 of Swift Package Indexing](https://share.transistor.fm/s/333d2750){:target='_blank'}.
@@ -506,10 +486,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, Wasm, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/tevelee/swift-graphs
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/91){:target='_blank'}.
@@ -537,10 +515,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, Wasm, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: Apache 2.0
             url: https://swiftpackageindex.com/sliemeobn/elementary
             note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/82){:target='_blank'}.
@@ -552,8 +528,7 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (macOS), Linux, and Android
+            platform_compatibility_tooltip: Apple (macOS) and Linux
             license: Apache 2.0
             url: https://swiftpackageindex.com/apple/swift-openapi-generator
             note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/84){:target='_blank'}.
@@ -566,8 +541,7 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (macOS), Linux, and Android
+            platform_compatibility_tooltip: Apple (macOS) and Linux
             license: MIT
             url: https://swiftpackageindex.com/franklefebvre/swift-export
             note: Linked to in [Issue 679 of iOS Dev Weekly](https://iosdevweekly.com/issues/679#DXo4Uf9){:target='_blank'}.
@@ -607,10 +581,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, Wasm, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/davbeck/swift-glob
             note: Discussed on [Episode 44 of Swift Package Indexing](https://share.transistor.fm/s/cbb0c6ad){:target='_blank'}.
@@ -701,9 +673,7 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (macOS, visionOS), Linux, Wasm, and Android
+            platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
             license: MIT
             url: https://swiftpackageindex.com/giginet/swift-testing-revolutionary
             note: Discussed on [Episode 46 of Swift Package Indexing](https://share.transistor.fm/s/08c0a3f9){:target='_blank'}.
@@ -751,9 +721,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, and Wasm
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: Apache 2.0
             url: https://swiftpackageindex.com/tayloraswift/swift-dom
             note: Nominated in [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/66){:target='_blank'}.
@@ -769,9 +738,7 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS), Linux, and
-              Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS) and Linux
             license: Apache 2.0
             url: https://swiftpackageindex.com/hummingbird-project/hummingbird
             note: Discussed on [Episode 45 of Swift Package Indexing](https://share.transistor.fm/s/53ee9157){:target='_blank'}.
@@ -807,8 +774,7 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (macOS, visionOS), Linux, and Android
+            platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
             license: MIT
             url: https://swiftpackageindex.com/m-barthelemy/AcmeSwift
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/63){:target='_blank'}.
@@ -832,10 +798,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, Wasm, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/mochidev/CodableDatastore
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/63){:target='_blank'}.
@@ -851,9 +815,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: Apache 2.0
             url: https://swiftpackageindex.com/funcmike/rabbitmq-nio
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/48){:target='_blank'}.
@@ -865,9 +828,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/mattcox/Pack
             note: Discussed on [Episode 43 of Swift Package Indexing](https://share.transistor.fm/s/2d4b1ba7){:target='_blank'}.
@@ -892,9 +854,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/swiftwasm/WasmKit
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/53){:target='_blank'}.
@@ -954,10 +915,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, Wasm, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: The Unlicense
             url: https://swiftpackageindex.com/designedbyclowns/GeoURI
             note: Discussed on [Episode 43 of Swift Package Indexing](https://share.transistor.fm/s/2d4b1ba7){:target='_blank'}.
@@ -969,10 +928,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, Wasm, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/pointfreeco/swift-perception
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/24){:target='_blank'}.
@@ -984,8 +941,7 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (macOS, visionOS), Linux, and Android
+            platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
             license: MIT
             url: https://swiftpackageindex.com/gh123man/Async-Channels
             note: Discussed on [Episode 42 of Swift Package Indexing](https://share.transistor.fm/s/c118cc9c){:target='_blank'}.
@@ -997,10 +953,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, Wasm, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/jonreid/ExpectToEventuallyEqual
             note: Discussed on [Episode 41 of Swift Package Indexing](https://share.transistor.fm/s/861890bb){:target='_blank'}.
@@ -1040,9 +994,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/swhitty/FlyingFox
             note: Discussed on [Episode 41 of Swift Package Indexing](https://share.transistor.fm/s/861890bb){:target='_blank'}.
@@ -1094,9 +1047,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/davedelong/time
             note:
@@ -1111,10 +1063,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, Wasm, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/0xLeif/Fork
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/29){:target='_blank'}.
@@ -1167,10 +1117,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, Wasm, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/jrothwell/VersionedCodable
             note: Discussed on [Episode 40 of Swift Package Indexing](https://share.transistor.fm/s/a452cfcd){:target='_blank'}.
@@ -1271,10 +1219,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Wasm
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, Wasm, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/mattpolzin/OpenAPIKit
             note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/12){:target='_blank'}.
@@ -1300,9 +1246,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/space-code/typhoon
             note: Discussed on [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}.
@@ -1344,9 +1289,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/davedelong/time
             note: Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/7){:target='_blank'}.
@@ -1370,9 +1314,8 @@ years:
             platform_compatibility:
               - Apple
               - Linux
-              - Android
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS),
-              Linux, and Android
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
             license: MIT
             url: https://swiftpackageindex.com/gohanlon/swift-memberwise-init-macro
             note: Discussed in [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}.
@@ -1440,8 +1383,7 @@ years:
             swift_compatibility: 5.10+
             platform_compatibility:
               - Apple
-              - Wasm
-            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS) and Wasm
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS)
             license: MIT
             url: https://swiftpackageindex.com/automerge/automerge-swift
             note: Discussed on [Episode 36 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/36-even-though-the-bug-is-fixed-its-not-over){:target='_blank'}.


### PR DESCRIPTION
This is a follow-up to #1113. Android and Wasm are not officially supported yet, so removing the compatibility status for them for now. This will be re-added in a future update once the platforms are supported.