### PR TITLE
Re-order the server packages

### DIFF
--- a/_data/new-data/get-started/cloud-services/tertiary-content-cloud-native.yml
+++ b/_data/new-data/get-started/cloud-services/tertiary-content-cloud-native.yml
@@ -1,18 +1,18 @@
 title: Explore cloud native packages
 tertiary_cards:
-  - name: Swift Prometheus
-    text: Client for the Prometheus monitoring system, supporting counters, gauges and histograms.
-    link_text: View on GitHub
-    link: https://github.com/swift-server/swift-prometheus
   - name: gRPC Swift
     text: The Swift language implementation of gRPC.
     link_text: View on GitHub
     link: https://github.com/grpc/grpc-swift
-  - name: Swift OPA
-    text:  Evaluate Open Policy Agent IR Plans compiled from Rego declarative policy. (pre-1.0 release)
-    link_text: View on GitHub
-    link: https://github.com/open-policy-agent/swift-opa
   - name: Swift OTel 
     text: OpenTelemetry client built for Swift observability libraries. (pre-1.0 release)
     link_text: View on GitHub
     link: https://github.com/swift-otel/swift-otel
+  - name: Swift Prometheus
+    text: Client for the Prometheus monitoring system, supporting counters, gauges and histograms.
+    link_text: View on GitHub
+    link: https://github.com/swift-server/swift-prometheus
+  - name: Swift OPA
+    text:  Evaluate Open Policy Agent IR Plans compiled from Rego declarative policy. (pre-1.0 release)
+    link_text: View on GitHub
+    link: https://github.com/open-policy-agent/swift-opa

--- a/_data/new-data/get-started/cloud-services/tertiary-content.yml
+++ b/_data/new-data/get-started/cloud-services/tertiary-content.yml
@@ -7,15 +7,15 @@ tertiary_cards:
     text: Generate Swift client and server code from an OpenAPI document.
     link_text: View on GitHub
     link: https://github.com/apple/swift-openapi-generator
-  - name: SwiftNIO
-    text: Cross-platform asynchronous event-driven network application framework.
-    link_text: View on GitHub
-    link: https://github.com/apple/swift-nio
-  - name: PostgresNIO
-    text: Non-blocking, event-driven Swift client for PostgreSQL.
-    link_text: View on GitHub
-    link: https://github.com/vapor/postgres-nio
   - name: Async HTTP Client
     text: Provides an HTTP Client library built on top of SwiftNIO.
     link_text: View on GitHub
     link: https://github.com/swift-server/async-http-client
+  - name: PostgresNIO
+    text: Non-blocking, event-driven Swift client for PostgreSQL.
+    link_text: View on GitHub
+    link: https://github.com/vapor/postgres-nio
+  - name: SwiftNIO
+    text: Cross-platform asynchronous event-driven network application framework.
+    link_text: View on GitHub
+    link: https://github.com/apple/swift-nio


### PR DESCRIPTION
The order of the server packages was a bit arbitrary. This PR re-orders them by sorting them from highest to lowest level, for their respective importance and then how production ready they are.