### PR TITLE
link from the documentation set into the new guide for building a vapor web server

### DIFF
--- a/_data/new-data/get-started/cloud-services/link-columns.yml
+++ b/_data/new-data/get-started/cloud-services/link-columns.yml
@@ -3,7 +3,7 @@ columns:
   - headline: Documentation
     links:
       - text: 'Build a web service with Vapor'
-        url: '/getting-started/vapor-web-server/'
+        url: 'https://docs.swift.org/getting-started-swift-server/tutorials/getting-started-swift-server/'
       - text: 'Swift server development guides'
         url: '/documentation/server/guides/'
       - text: 'Swift on AWS documentation'


### PR DESCRIPTION
Resolving possible oversight - linking to newer content on building a web server with Vapor from the documentation panel  (link columns)