### PR TITLE
Use a curlbash script for installing swiftly

### DIFF
--- a/_data/new-data/install/linux/releases.yml
+++ b/_data/new-data/install/linux/releases.yml
@@ -3,20 +3,7 @@ latest-release:
     pre-code-text: |
       The Swiftly installer manages Swift and its dependencies. It supports switching between different versions and downloading updates.
     headline: Swiftly
-    tabs:
-      - label: Bash
-        code: |-
-          curl -O https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz && \
-          tar zxf swiftly-$(uname -m).tar.gz && \
-          ./swiftly init --quiet-shell-followup && \
-          . "${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}/env.sh" && \
-          hash -r
-      - label: Fish
-        code: |-
-          curl -O https://download.swift.org/swiftly/linux/swiftly-(uname -m).tar.gz && \
-          tar zxf swiftly-(uname -m).tar.gz && \
-          ./swiftly init --quiet-shell-followup && \
-          set -q SWIFTLY_HOME_DIR && source "$SWIFTLY_HOME_DIR/env.fish" || source ~/.local/share/swiftly/env.fish
+    code: curl -fsSL https://swift.org/swiftly-install | sh
     links:
       - href: 'https://raw.githubusercontent.com/swiftlang/swiftly/refs/heads/main/LICENSE.txt'
         copy: 'License: Apache-2.0'

--- a/_data/new-data/install/macos/releases.yml
+++ b/_data/new-data/install/macos/releases.yml
@@ -3,20 +3,7 @@ latest-release:
     pre-code-text: |
       To download toolchains from Swift.org, use the Swiftly toolchain installer. Swift.org toolchains support Static Linux SDK, include experimental features like Embedded Swift and support for WebAssembly.
     headline: Swiftly
-    tabs:
-      - label: Bash
-        code: |
-          curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg && \
-          installer -pkg swiftly.pkg -target CurrentUserHomeDirectory && \
-          ~/.swiftly/bin/swiftly init --quiet-shell-followup && \
-          . "${SWIFTLY_HOME_DIR:-$HOME/.swiftly}/env.sh" && \
-          hash -r
-      - label: Fish
-        code: |
-          curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg && \
-          installer -pkg swiftly.pkg -target CurrentUserHomeDirectory && \
-          ~/.swiftly/bin/swiftly init --quiet-shell-followup && \
-          set -q SWIFTLY_HOME_DIR && source "$SWIFTLY_HOME_DIR/env.fish" || source ~/.swiftly/env.fish
+    code: curl -fsSL https://swift.org/swiftly-install | sh
     links:
       - href: 'https://raw.githubusercontent.com/swiftlang/swiftly/refs/heads/main/LICENSE.txt'
         copy: 'License: Apache-2.0'

--- a/install/linux/index.md
+++ b/install/linux/index.md
@@ -8,7 +8,7 @@ title: Install Swift - Linux
 <div class="content">
   <div class="release-box section">
     <div class="content">
-      {% include new-includes/components/code-box.html with-tabs = true content = site.data.new-data.install.linux.releases.latest-release.swiftly %}
+      {% include new-includes/components/code-box.html content = site.data.new-data.install.linux.releases.latest-release.swiftly %}
     </div>
   </div>
   <div class="release-box section">

--- a/install/macos/index.md
+++ b/install/macos/index.md
@@ -11,7 +11,7 @@ title: Install Swift - macOS
 <div class="content">
   <div class="release-box section">
     <div class="content">
-      {% include new-includes/components/code-box.html with-tabs = true content = site.data.new-data.install.macos.releases.latest-release.swiftly%}
+      {% include new-includes/components/code-box.html content = site.data.new-data.install.macos.releases.latest-release.swiftly%}
     </div>
   </div>
   <div class="release-box section">

--- a/swiftly-install
+++ b/swiftly-install
@@ -1,0 +1,38 @@
+#!/bin/bash -e
+# Install script for Swiftly
+# Usage: curl -fsSL https://swift.org/swiftly-install | sh
+OS_NAME=$(uname -s)
+OS_ARCH=$(uname -m)
+TMPDIR=$(mktemp -d)
+
+cd ${TMPDIR}
+
+case "$OS_NAME" in
+    "Linux")
+        curl -fsSLO https://download.swift.org/swiftly/linux/swiftly-${OS_ARCH}.tar.gz
+        tar zxf swiftly-${OS_ARCH}.tar.gz
+        ./swiftly init
+        SWIFTLY_HOME_DIR=${SWIFTLY_HOME_DIR:-$HOME/.swiftly}
+        ;;
+    "Darwin")
+        curl -fsSLO https://download.swift.org/swiftly/darwin/swiftly.pkg
+        installer -pkg swiftly.pkg -target CurrentUserHomeDirectory
+        ~/.swiftly/bin/swiftly init
+        SWIFTLY_HOME_DIR=${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}
+        ;;
+    *)
+        echo "Unknown platform: $OS_NAME"
+        echo "This script supports Linux and Darwin/macOS only"
+        exit 1
+        ;;
+esac
+
+echo "Swiftly installed! Run the following command to set up your environment:"
+PARENT_SHELL=$(ps -o comm= -p "$PPID")
+if [ "$PARENT_SHELL" = "fish" ]; then
+    echo "source ${SWIFTLY_HOME_DIR}/env.fish"
+else
+    # Not fish: assume sh-compatible (bash/zsh)
+    echo "source ${SWIFTLY_HOME_DIR}/env.sh"
+fi
+


### PR DESCRIPTION
### Motivation:

The current recommendation for installing Swiftly on [macOS](https://www.swift.org/install/macos/) and [Linux](https://www.swift.org/install/linux/) involves a gnarly multi-line shell-specific blob of code that the user needs to paste into their shell. 

Curlbash scripts (i.e., `curl https://… | sh`) are a common and portable way to install software for UNIX-like systems. They are used by popular packages like [rbenv](https://rbenv.org), [Homebrew](https://brew.sh), [Rust](https://www.rust-lang.org/tools/install), [NVM](https://github.com/nvm-sh/nvm#installing-and-updating), [Tailscale](https://tailscale.com/kb/1031/install-linux), and [Deno](https://docs.deno.com/runtime/getting_started/installation/).

### Modifications:

Add a `swiftly-install` shell script for installing swiftly and recommend using it from the "Install" pages.

### Result:

The installation instructions will be briefer and nicer and not require that the user know what shell they are running.

Before:

<img width="1269" height="943" alt="Screenshot 2025-08-16 at 18 03 08" src="https://github.com/user-attachments/assets/2cf182dd-c6e6-48e8-99d8-c56a813c8a6f" />

After:

<img width="1275" height="783" alt="Screenshot 2025-08-16 at 18 03 23" src="https://github.com/user-attachments/assets/d574ff28-b3c6-4d79-8037-60a6abea5392" />


