### PR TITLE
Revert "[windows] update the install instructions to use Python 3.10 (#1140)

### DIFF
--- a/_includes/install/_windows_dependencies.md
+++ b/_includes/install/_windows_dependencies.md
@@ -5,7 +5,7 @@ Swift has the following general dependencies:
 - Git (used by Swift Package Manager)
 - Python[^1] (used by the debugger - LLDB)
 
-[^1]: The Windows binaries are built against Python 3.10
+[^1]: The Windows binaries are built against Python 3.9
 
 Swift on Windows has the following additional platform specific dependencies:
 

--- a/install/windows/_manual.md
+++ b/install/windows/_manual.md
@@ -16,7 +16,7 @@ The following Visual Studio components should be installed:
 
 You should also install the following dependencies:
 
-- [Python 3.10._x_](https://www.python.org/downloads/windows/) [^3]
+- [Python 3.9._x_](https://www.python.org/downloads/windows/) [^3]
 - [Git for Windows](https://git-scm.com/downloads/win)
 
 [^3]: You may install the latest `.x` patch release, but ensure you use the specified `major.minor` version of Python for optimal compatibility.

--- a/install/windows/_windows.md
+++ b/install/windows/_windows.md
@@ -10,7 +10,7 @@ Swift has the following general dependencies:
 - Git (used by Swift Package Manager)
 - Python[^1] (used by the debugger - LLDB)
 
-[^1]: The Windows binaries are built against Python 3.10
+[^1]: The Windows binaries are built against Python 3.9
 
 Swift on Windows has the following additional platform specific dependencies:
 

--- a/install/windows/manual/index.md
+++ b/install/windows/manual/index.md
@@ -21,7 +21,7 @@ The following Visual Studio components should be installed:
 
 You should also install the following dependencies:
 
-- [Python 3.10._x_](https://www.python.org/downloads/windows/) [^3]
+- [Python 3.9._x_](https://www.python.org/downloads/windows/) [^3]
 - [Git for Windows](https://git-scm.com/downloads/win)
 
 [^3]: You may install the latest `.x` patch release, but ensure you use the specified `major.minor` version of Python for optimal compatibility.


### PR DESCRIPTION
This reverts https://github.com/swiftlang/swift-org-website/pull/1140.

We should remerge the original patch once `6.2.1` is released.
