### PR TITLE
Updated Community Showcase packages for September

### DIFF
--- a/_data/packages/packages.yml
+++ b/_data/packages/packages.yml
@@ -9,57 +9,57 @@ categories:
       organised via [this thread in the Swift Forums](https://forums.swift.org/t/68168)
       and curated by the [Swift Website Workgroup](https://www.swift.org/website-workgroup/).
     packages:
-      - name: Equatable
-        description: Provides macros to generate `Equatable` conformances for structs,
-          optimizing SwiftUI diffing and performance by eliminating boilerplate code and
-          preventing unnecessary re-renders. Ideal for large app scalability.
-        owner: Ordo One
-        swift_compatibility: 6.0+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS) and Linux
-        license: Apache 2.0
-        url: https://swiftpackageindex.com/ordo-one/equatable
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/148){:target='_blank'}.
-      - name: TextDiffing
-        description: Highlights differences between texts using `AttributedString` or
-          `NSAttributedString`. Supports customization of appearance, word- and character-level
-          diffing, and is lightweight.
-        owner: "Simon B. St\xF8vring"
+      - name: Probing
+        description: Probing provides breakpoints for testing Swift code, enabling precise
+          control and observation of state transitions in asynchronous functions, addressing
+          challenges like unobservable states, non-determinism, and limited runtime control.
+        owner: Kamil Strzelecki
         swift_compatibility: 6.1+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS)
-        license: MIT
-        url: https://swiftpackageindex.com/simonbs/TextDiffing
-        note: Discussed on [Episode 59 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/59-at-least-mine-was-related-to-swift){:target='_blank'}.
-      - name: Objects2XLSX
-        description: Converts Swift objects to Excel (.xlsx) files with a type-safe, declarative
-          API. Supports styling, multiple worksheets, async data fetching, and real-time
-          progress tracking for professional spreadsheet creation.
-        owner: "Fatbobman(\u4E1C\u5761\u8098\u5B50)"
-        swift_compatibility: 6.0+
         platform_compatibility:
           - Apple
           - Linux
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
           Linux
-        license: Apache 2.0
-        url: https://swiftpackageindex.com/fatbobman/Objects2XLSX
+        license: MIT
+        url: https://swiftpackageindex.com/NSFatalError/Probing
+        note: Discussed on [Episode 58 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/58-people-used-to-hand-code-assembly){:target='_blank'}.
+      - name: TranslateKit
+        description: TranslateKit SDK simplifies app localization by providing 2000+ pre-localized
+          strings and semantic key generation. It enhances translation accuracy and consistency
+          using Apple's translations and smart key management.
+        owner: FlineDev
+        swift_compatibility: 6.0+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+        license: MIT
+        url: https://swiftpackageindex.com/FlineDev/TranslateKitSDK
         note: Discussed on [Episode 59 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/59-at-least-mine-was-related-to-swift){:target='_blank'}.
-      - name: vault-courier
-        description: Swift client for securely retrieving and provisioning secrets with
-          Hashicorp Vault and OpenBao. Supports key/value storage, credential generation,
-          and AppRole/Token authentication.
-        owner: Vault Courier
+      - name: EmailValidator
+        description: Swift Email Validator performs robust, RFC-compliant email validation
+          with WordPress-inspired logic, supporting major providers and offering Swift-native
+          APIs for high-performance email handling and processing.
+        owner: David Michael
         swift_compatibility: 6.1+
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
-        license: Apache 2.0
-        url: https://swiftpackageindex.com/vault-courier/vault-courier
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
+        license: No license
+        url: https://swiftpackageindex.com/arraypress/swift-email-validator
+        note: Discussed on [Episode 60 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/60-filename-suffixes-in-swift-package-prefixes){:target='_blank'}.
+      - name: swift-mocking
+        description: Swift Mocking generates mock dependencies using macros, supporting
+          various property and method types, concurrency, and protocol conformance, including
+          actors and associated types.
+        owner: Fetch
+        swift_compatibility: 6.0+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+        license: MIT
+        url: https://swiftpackageindex.com/fetch-rewards/swift-mocking
         note: Discussed on [Episode 57 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/57-how-many-of-the-same-packages-can-we-pick){:target='_blank'}.
   - name: Packages with Macros
     slug: macros

--- a/_data/packages/showcase-history.yml
+++ b/_data/packages/showcase-history.yml
@@ -1,6 +1,61 @@
 years:
   - year: 2025
     months:
+      - month: August
+        slug: august
+        packages:
+          - name: Equatable
+            description: Provides macros to generate `Equatable` conformances for structs,
+              optimizing SwiftUI diffing and performance by eliminating boilerplate code
+              and preventing unnecessary re-renders. Ideal for large app scalability.
+            owner: Ordo One
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS) and Linux
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/ordo-one/equatable
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/148){:target='_blank'}.
+          - name: TextDiffing
+            description: Highlights differences between texts using `AttributedString` or
+              `NSAttributedString`. Supports customization of appearance, word- and character-level
+              diffing, and is lightweight.
+            owner: "Simon B. St\xF8vring"
+            swift_compatibility: 6.1+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS)
+            license: MIT
+            url: https://swiftpackageindex.com/simonbs/TextDiffing
+            note: Discussed on [Episode 59 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/59-at-least-mine-was-related-to-swift){:target='_blank'}.
+          - name: Objects2XLSX
+            description: Converts Swift objects to Excel (.xlsx) files with a type-safe,
+              declarative API. Supports styling, multiple worksheets, async data fetching,
+              and real-time progress tracking for professional spreadsheet creation.
+            owner: "Fatbobman(\u4E1C\u5761\u8098\u5B50)"
+            swift_compatibility: 6.0+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/fatbobman/Objects2XLSX
+            note: Discussed on [Episode 59 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/59-at-least-mine-was-related-to-swift){:target='_blank'}.
+          - name: vault-courier
+            description: Swift client for securely retrieving and provisioning secrets with
+              Hashicorp Vault and OpenBao. Supports key/value storage, credential generation,
+              and AppRole/Token authentication.
+            owner: Vault Courier
+            swift_compatibility: 6.1+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/vault-courier/vault-courier
+            note: Discussed on [Episode 57 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/57-how-many-of-the-same-packages-can-we-pick){:target='_blank'}.
       - month: July
         slug: july
         packages:


### PR DESCRIPTION
This update contains the [Community Showcase packages](https://www.swift.org/packages/showcase.html) for September.

Packages in the Community Showcase are nominated by the community in [this thread on the Swift forums](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168) and voted on by the [SWWG](https://www.swift.org/website-workgroup/).

<img width="1632" height="1386" alt="Screenshot 2025-09-08 at 12 27 59@2x" src="https://github.com/user-attachments/assets/01375156-5bca-46a7-a4ea-97c3edb03847" />
