### PR TITLE
OpenAPI doc updates for Swift 6.2

### DIFF
--- a/openapi/TestSwiftOrgClient/swiftorgClient/Tool.swift
+++ b/openapi/TestSwiftOrgClient/swiftorgClient/Tool.swift
@@ -52,8 +52,20 @@ struct Tool {
                 work: { _ = try await client.listReleases().ok.body.json }
             ),
         ]
+        struct DevToolchainBranchPlatform: Hashable {
+            var branch: Components.Schemas.KnownSourceBranch
+            var platform: Components.Schemas.KnownPlatformIdentifier
+        }
+        let excluded: Set<DevToolchainBranchPlatform> = [
+            .init(branch: ._6_0, platform: .debian12),
+            .init(branch: ._6_0, platform: .fedora39),
+            .init(branch: ._6_0, platform: .ubuntu2404),
+        ]
         for branch in Components.Schemas.KnownSourceBranch.allCases {
             for platform in Components.Schemas.KnownPlatformIdentifier.allCases {
+                guard !excluded.contains(.init(branch: branch, platform: platform)) else {
+                    continue
+                }
                 tests.append(
                     .init(
                         name: "listDevToolchains(\(branch.rawValue), \(platform.rawValue))",

--- a/openapi/swiftorg.yaml
+++ b/openapi/swiftorg.yaml
@@ -262,7 +262,6 @@ components:
         - '6.0'
         - '6.1'
         - '6.2'
-        - '6.3'
     SourceBranch:
       anyOf:
         - $ref: '#/components/schemas/KnownSourceBranch'

--- a/openapi/swiftorg.yaml
+++ b/openapi/swiftorg.yaml
@@ -134,12 +134,12 @@ components:
           type: string
           pattern: \d+\.\d+(\.\d+)?
           description: Version number of the Swift release.
-          example: '6.0.2'
+          example: '6.2.0'
         date:
           type: string
           pattern: \d{4}-\d{2}-\d{2}
           description: Release date of the Swift version.
-          example: '2024-10-28'
+          example: '2025-09-15'
         platforms:
           type: array
           description: List of supported platforms for this release.
@@ -172,10 +172,13 @@ components:
       enum:
         - amazonlinux2
         - centos7
+        - debian12
+        - fedora39
         - macos
         - ubi9
         - ubuntu2004
         - ubuntu2204
+        - ubuntu2404
         - windows10
     PlatformIdentifier:
       anyOf:
@@ -191,6 +194,8 @@ components:
       type: string
       enum:
         - Swift Development Snapshot
+        - Swift Static SDK Development Snapshot
+        - Swift Wasm SDK Development Snapshot
     DevToolchainKind:
       anyOf:
         - $ref: '#/components/schemas/KnownDevToolchainKind'
@@ -257,6 +262,7 @@ components:
         - '6.0'
         - '6.1'
         - '6.2'
+        - '6.3'
     SourceBranch:
       anyOf:
         - $ref: '#/components/schemas/KnownSourceBranch'
@@ -273,6 +279,8 @@ components:
         - Linux
         - Windows
         - static-sdk
+        - wasm
+      example: Linux
     PlatformType:
       anyOf:
         - $ref: '#/components/schemas/KnownPlatformType'
@@ -311,7 +319,12 @@ components:
           description: List of supported architectures.
         checksum:
           type: string
-          description: SHA-256 Checksum of the static SDK, if this platform is the static SDK.
+          description: SHA-256 checksum of the Swift SDK.
+          example: 'd2225840e592389ca517bbf71652f7003dbf45ac35d1e57d98b9250368769378'
+        docker:
+          type: string
+          description: The tag of the container image.
+          example: '6.2-noble'
       required:
         - name
         - platform


### PR DESCRIPTION
### Motivation:

The Swift.org OpenAPI doc was missing newer platforms, Swift versions, and fields added recently.

### Modifications:

- Added the `docker` field in the releases array, pointing to the container tag
- Added enum cases for the Static and WASM SDKs for toolchain types
- Added `debian12`, `fedora39`, `ubuntu2404` to the list of platforms that toolchains exist for
- Added/updated some example values

### Result:

More up-to-date OpenAPI doc, useful to tools like swiftly and others who generate code from the OpenAPI doc.
