### PR TITLE
Update 2025-09-15-swift-6.2-released.md

### DIFF
--- a/_posts/2025-09-15-swift-6.2-released.md
+++ b/_posts/2025-09-15-swift-6.2-released.md
@@ -99,7 +99,7 @@ These workflow improvements make it easier to work on Swift projects in your env
 
 ### Precise warning control
 
-Swift 6.2 introduces enhances how you manage compiler warnings by allowing control at the *diagnostic group* level. A diagnostic group is a category of warnings identified by a name. You can specify the desired behavior of warnings in a diagnostic group in a Swift package manifest using the [`treatWarning`](https://docs.swift.org/swiftpm/documentation/packagedescription/swiftsetting/treatwarning(_:as:_:)/) method on `SwiftSetting`, or promote all warnings to errors using the [`treatAllWarnings`](https://docs.swift.org/swiftpm/documentation/packagedescription/swiftsetting/treatallwarnings(as:_:)) method. For example, you can promote all warnings to errors except for warnings about uses of deprecated APIs:
+Swift 6.2 enhances how you manage compiler warnings by allowing control at the *diagnostic group* level. A diagnostic group is a category of warnings identified by a name. You can specify the desired behavior of warnings in a diagnostic group in a Swift package manifest using the [`treatWarning`](https://docs.swift.org/swiftpm/documentation/packagedescription/swiftsetting/treatwarning(_:as:_:)/) method on `SwiftSetting`, or promote all warnings to errors using the [`treatAllWarnings`](https://docs.swift.org/swiftpm/documentation/packagedescription/swiftsetting/treatallwarnings(as:_:)) method. For example, you can promote all warnings to errors except for warnings about uses of deprecated APIs:
 
 ```swift
 .target(


### PR DESCRIPTION
### Motivation:

Fix typo

### Modifications:

Removed duplicate verb

