### PR TITLE
Remove outdated wording in `wasm-getting-started.md`

### DIFF
--- a/documentation/articles/wasm-getting-started.md
+++ b/documentation/articles/wasm-getting-started.md
@@ -29,7 +29,7 @@ The distributed artifact bundles also include support for the experimental Embed
 
 1. [Install `swiftly` per the instructions](https://www.swift.org/install/) for the platform that you're bulding on.
 
-2. Install Swift {{ release_name }} with `swiftly install {{ release_name }}`, note the exact snapshot date component in the output of this command.
+2. Install Swift {{ release_name }} with `swiftly install {{ release_name }}`.
 
 3. Select the installed toolchain with `swiftly use {{ release_name }}`.
 


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

After https://github.com/swiftlang/swift-org-website/pull/1162 this clause is no longer needed.