### PR TITLE
Clean up documentation in OpenAPI `swiftorg.yaml`

### DIFF
--- a/openapi/swiftorg.yaml
+++ b/openapi/swiftorg.yaml
@@ -64,7 +64,7 @@ paths:
           $ref: '#/components/schemas/SourceBranch'
     get:
       operationId: listStaticSDKDevToolchains
-      summary: Fetch all static SDK development toolchains
+      summary: Fetch all development static Linux Swift SDKs
       tags:
         - Toolchains
       responses:
@@ -83,7 +83,7 @@ paths:
           $ref: '#/components/schemas/SourceBranch'
     get:
       operationId: listWasmSDKDevToolchains
-      summary: Fetch all SDK for WebAssembly toolchains
+      summary: Fetch all development Swift SDKs for WebAssembly
       tags:
         - Toolchains
       responses:


### PR DESCRIPTION
Endpoints providing information about Swift SDKs should be documented as such, as they don't distribute any toolchains as stated in the currently incorrect documentation strings.