### PR TITLE
Fix link to Android workgroup discussion forum

### DIFF
--- a/android-workgroup/index.md
+++ b/android-workgroup/index.md
@@ -22,7 +22,7 @@ The Android workgroup will:
 
 ## Communication
 
-The Swift Android workgroup uses the [Swift Android forum](https://forums.swift.org/c/platform/android) for general discussions. It can also be contacted privately by messaging [@android-workgroup](https://forums.swift.org/g/android-workgroup) on the Swift Forums.
+The Swift Android workgroup uses the [Swift Android forum](https://forums.swift.org/c/platform/android/115) for general discussions. It can also be contacted privately by messaging [@android-workgroup](https://forums.swift.org/g/android-workgroup) on the Swift Forums.
 
 ## Membership
 

--- a/android-workgroup/index.md
+++ b/android-workgroup/index.md
@@ -22,7 +22,7 @@ The Android workgroup will:
 
 ## Communication
 
-The Swift Android workgroup uses the [Swift Android forum](https://forums.swift.org/c/development/android) for general discussions. It can also be contacted privately by messaging [@android-workgroup](https://forums.swift.org/g/android-workgroup) on the Swift Forums.
+The Swift Android workgroup uses the [Swift Android forum](https://forums.swift.org/c/platform/android) for general discussions. It can also be contacted privately by messaging [@android-workgroup](https://forums.swift.org/g/android-workgroup) on the Swift Forums.
 
 ## Membership
 


### PR DESCRIPTION
The Android workgroup forum seems to have been moved from https://forums.swift.org/c/development/android to https://forums.swift.org/c/platform/android with no redirect (as pointed out at https://forums.swift.org/t/link-to-this-discussion-forum-is-broken-in-documentation/82336/2). This PR fixes the link.
