### PR TITLE
Add "Sam Khouri" to "Contributor Experience Workgroup"

### DIFF
--- a/_data/contributer-experience-workgroup/members.yml
+++ b/_data/contributer-experience-workgroup/members.yml
@@ -50,6 +50,10 @@
   github: xedin
   affiliation: Chair
 
+- name: Sam Khouri
+  github: bkhouri
+  affiliation:
+
 - name: Suyash Srijan	
   github: theblixguy
   affiliation: 


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

Sam join the group a few month ago but we didn't add him to the member list. This change aims to rectify it.

### Modifications:

- Added new entry for Sam to `_data/contributer-experience-workgroup/members.yml`

### Result:

The Contributor Experience Workgroup page would list Sam as a member now.
