### PR TITLE
docs: Add troubleshooting section to Android getting started guide

### DIFF
--- a/documentation/articles/swift-sdk-for-android-getting-started.md
+++ b/documentation/articles/swift-sdk-for-android-getting-started.md
@@ -150,6 +150,35 @@ $ adb shell /data/local/tmp/hello
 Hello, world!
 ```
 
+### Troubleshooting
+
+#### Missing header errors after SDK installation
+
+If you see errors like:
+
+```
+error: 'semaphore.h' file not found
+error: 'stddef.h' file not found
+```
+
+This means the `setup-android-sdk.sh` script was not run after installing the SDK. Make sure `ANDROID_NDK_HOME` is set and run:
+
+```console
+$ export ANDROID_NDK_HOME=/path/to/android-ndk-r27d
+$ cd ~/Library/org.swift.swiftpm || cd ~/.swiftpm
+$ ./swift-sdks/*/swift-android/scripts/setup-android-sdk.sh
+```
+
+#### NDK version mismatch
+
+The Swift SDK for Android requires NDK version 27 or later. If you see:
+
+```
+setup-android-sdk.sh: error: minimum NDK version 27 required
+```
+
+Download NDK r27d or later from the [NDK Downloads page](https://developer.android.com/ndk/downloads).
+
 ### Next Steps
 
 Congratulations, you have built and run your first Swift program on Android!


### PR DESCRIPTION
## Summary

Adds a troubleshooting section to the Swift SDK for Android getting started guide, documenting common errors and their solutions.

## Changes

Added troubleshooting guidance for:
- **Missing header errors** (`semaphore.h`, `stddef.h` not found) - occurs when `setup-android-sdk.sh` is not run after SDK installation
- **NDK version mismatch** - when NDK version is below the required v27

## Motivation

New users often skip or miss the `setup-android-sdk.sh` step and encounter cryptic header errors. This section helps them quickly diagnose and fix the issue.