### PR TITLE
Android getting started: just hard-code the last patch release version

### DIFF
--- a/documentation/articles/swift-sdk-for-android-getting-started.md
+++ b/documentation/articles/swift-sdk-for-android-getting-started.md
@@ -31,9 +31,6 @@ Cross-compilation for Android requires installing three separate components:
 {% assign tag = site.data.builds.swift_releases.last.tag %}
 {% assign version = site.data.builds.swift_releases.last.name %}
 {% assign release_count = site.data.builds.swift_releases.size %}
-{% assign previous_index = release_count | minus: 2 %}
-{% assign previous_release = site.data.builds.swift_releases | slice: previous_index %}
-{% assign previous_sdk_name = previous_release.tag | append: "_android" %}
 {% assign tag_downcase = site.data.builds.swift_releases.last.tag | downcase %}
 {% assign base_url = "https://download.swift.org/" | append: tag_downcase | append: "/android-sdk/" | append: tag | append: "/" | append: tag %}
 {% assign command = "swift sdk install " | append: base_url | append: "_android" | append: ".artifactbundle.tar.gz --checksum " | append: platform.checksum %}
@@ -82,7 +79,7 @@ $ swift sdk list
 Make sure to remove any old Android SDKs you have installed:
 
 ```console
-$ swift sdk remove {{previous_sdk_name}}
+$ swift sdk remove swift-6.3.2-RELEASE_android
 ```
 
 #### 3. Install and configure the Android NDK


### PR DESCRIPTION
Automating it wasn't working, and this will no longer be needed with the upcoming 6.4 release.