### PR TITLE
[cxx-interop] Update doc for foreign reference type inheritance

### DIFF
--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -1393,6 +1393,15 @@ object2.doSomething()
 // `object` will be released here.
 ```
 
+When a C++ type inherits from a base type that is annotated as a reference type, the Swift compiler automatically infers that the derived type is also a reference type.
+This inference applies to all three reference type annotations: `SWIFT_SHARED_REFERENCE`, `SWIFT_IMMORTAL_REFERENCE`, and `SWIFT_UNSAFE_REFERENCE`.
+It also applies when the base type is annotated through API notes rather than in the header itself.
+
+A type that inherits from a `SWIFT_SHARED_REFERENCE` base type uses the same `retain` and `release` functions as its base class.
+A type that inherits from a `SWIFT_IMMORTAL_REFERENCE` or a `SWIFT_UNSAFE_REFERENCE` base type is imported as an unmanaged class, just like its base class.
+
+Shared reference types and immortal (or unsafe) reference types cannot be mixed within a single inheritance chain.
+
 #### Constructing objects of Shared Reference Types from Swift
 
 As demonstrated in the provided example, starting from Swift 6.2, you can create instances of `SWIFT_SHARED_REFERENCE` types by invoking their initializers.
@@ -1417,17 +1426,6 @@ let object = SharedObject(42)
 
 Note that if a C++ constructor and a user-annotated static factory (using `SWIFT_NAME`) have identical parameter signatures, Swift favors the static factory when resolving initializer calls. 
 This is particularly useful when you want to use a custom allocator or want to disable direct construction entirely and expose only factories.
-
-#### Inference of Shared Reference behaviour in Derived Types
-
-When a C++ type inherits from a `SWIFT_SHARED_REFERENCE` base type, the Swift compiler automatically infers `SWIFT_SHARED_REFERENCE` annotation for the derived type.
-The derived type also gets imported as a reference type, and uses the same `retain` and `release` functions as its base class.
-This inference works as long as all the annotated base types in the inheritance chain (including multiple or indirect inheritance) have the same `retain` and `release` functions.
-If multiple base types have conflicting `retain` or `release` functions, the derived type is imported as a Swift value type, and the compiler emits a warning.
-
-
-Note that this inference currently applies only to `SWIFT_SHARED_REFERENCE`. 
-It does not apply to types annotated with `SWIFT_IMMORTAL_REFERENCE` or `SWIFT_UNSAFE_REFERENCE`.
 
 #### Calling conventions when returning Shared Reference Types from C++ to Swift
 


### PR DESCRIPTION
Swift infers that derived types are foreign reference types when the base type is annotated with `SWIFT_UNSAFE_REFERENCE`, or `SWIFT_IMMORTAL_REFERENCE`, unlike what the documentation claimed.

rdar://184040817