### PR TITLE
fixes links from the getting started pages into Embedded content

### DIFF
--- a/_data/new-data/get-started/embedded/hero.yml
+++ b/_data/new-data/get-started/embedded/hero.yml
@@ -1,7 +1,7 @@
 headline: Create embedded software with Swift
 body: Develop efficient, reliable firmware for devices like microcontrollers
 link:
-  url: https://docs.swift.org/embedded/documentation/embedded/waystogetstarted
+  url: https://docs.swift.org/embedded/documentation/embedded/introduction
   text: Get Started
 boxes:
   - title: Safe

--- a/_data/new-data/get-started/embedded/link-columns.yml
+++ b/_data/new-data/get-started/embedded/link-columns.yml
@@ -5,7 +5,7 @@ columns:
       - text: Embedded Swift documentation
         url: 'https://docs.swift.org/embedded/documentation/embedded'
       - text: Getting started with Embedded Swift
-        url: 'https://docs.swift.org/embedded/documentation/embedded/waystogetstarted'
+        url: 'https://docs.swift.org/embedded/documentation/embedded/introduction'
       - text: Embedded Swift vision document
         url: 'https://github.com/swiftlang/swift-evolution/blob/main/visions/embedded-swift.md'
       - text: Embedded Swift example projects


### PR DESCRIPTION
fixes links to embedded content

### Motivation:

In swiftlang/swift-embedded-examples, the `WaysToGetStarted.md` article was merged into `Introduction.md`, which meant the existing links no longer worked.

### Modifications:

updated two broken links using this stale slug:
  - _data/new-data/get-started/embedded/hero.yml — the main "Get Started" hero button
  - _data/new-data/get-started/embedded/link-columns.yml — the "Getting started with Embedded Swift" link mentioned in the comment

### Result:

slugs from the embedded getting started page redirect to the introduction page
