### PR TITLE
[Embedded swift] Fix links for "Get Started"

### DIFF
--- a/_data/new-data/get-started/embedded/hero.yml
+++ b/_data/new-data/get-started/embedded/hero.yml
@@ -1,7 +1,7 @@
 headline: Create embedded software with Swift
 body: Develop efficient, reliable firmware for devices like microcontrollers
 link:
-  url: https://docs.swift.org/embedded/documentation/embedded/waystogetstarted
+  url: https://docs.swift.org/embedded/documentation/embedded/installembeddedswift
   text: Get Started
 boxes:
   - title: Safe

--- a/_data/new-data/get-started/embedded/link-columns.yml
+++ b/_data/new-data/get-started/embedded/link-columns.yml
@@ -5,7 +5,7 @@ columns:
       - text: Embedded Swift documentation
         url: 'https://docs.swift.org/embedded/documentation/embedded'
       - text: Getting started with Embedded Swift
-        url: 'https://docs.swift.org/embedded/documentation/embedded/waystogetstarted'
+        url: 'https://docs.swift.org/embedded/documentation/embedded/installembeddedswift'
       - text: Embedded Swift vision document
         url: 'https://github.com/swiftlang/swift-evolution/blob/main/visions/embedded-swift.md'
       - text: Embedded Swift example projects


### PR DESCRIPTION
Documentation changes for Embedded Swift broke this link. Point to the installation guide as the entrypoint for getting started with Embedded Swift.
