### PR TITLE
[Windows] Update the manual install page to Windows 11 SDK 22621

### DIFF
--- a/install/windows/manual/index.md
+++ b/install/windows/manual/index.md
@@ -13,7 +13,7 @@ The following Visual Studio components should be installed:
 |-----------|------------------|
 | MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest)[^1] | Microsoft.VisualStudio.Component.VC.Tools.x86.x64 |
 | MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)[^1] | Microsoft.VisualStudio.Component.VC.Tools.ARM64 |
-| Windows 11 SDK (10.0.22000.0)[^2] | Microsoft.VisualStudio.Component.Windows11SDK.22000 |
+| Windows 11 SDK (10.0.22621.0)[^2] | Microsoft.VisualStudio.Component.Windows11SDK.22621 |
 
 [^1]: At minimum, Swift requires the build tools that match your machine architecture. Installing other architectures is recommended in order to cross-compile Swift binaries to run on different machine architectures.
 


### PR DESCRIPTION
### Motivation:

#1248 moved the winget path from `Windows11SDK.22000` to `Windows11SDK.22621`, changing only `_data/new-data/install/windows/releases.yml`. The component table on this page was written once, in 62007cd7 (#846), and still says 22000.

The Visual Studio 2022 installer no longer offers that component. Checked on Windows 11 (build 26200, x64) against the `VisualStudio.17.Release` catalog on disk, 17.14.37 (July 2026): it carries `Windows11SDK.22621`, titled "Windows 11 SDK (10.0.22621.0)", and `Windows11SDK.26100`. The string `22000` occurs once in that 18 MB catalog, as an OS version bound, never as a component id. Retired components do stay listed and labelled, for example "Windows 10 SDK (10.0.19041.0) (Out of support)"; 22000 is absent entirely. The catalog covers Community, Professional, Enterprise and Build Tools.

The other two rows in the table still match the installer titles character-for-character.

### Modifications:

Updated the SDK row to `Windows 11 SDK (10.0.22621.0)` / `Microsoft.VisualStudio.Component.Windows11SDK.22621`.

### Result:

The component named on this page can be selected in the installer, and matches the winget command. Footnote 2 still holds, since 26100 remains available as a newer SDK.

The same id is also on the winget and scoop pages, which this change leaves alone.
