### PR TITLE
draft content for a short blog post about the new docs site

### DIFF
--- a/_posts/2026-08-28-swifts-new-documentation-site.md
+++ b/_posts/2026-08-28-swifts-new-documentation-site.md
@@ -1,0 +1,36 @@
+---
+layout: new-layouts/post
+published: true
+date: 2026-08-28 10:00:00
+title: "Swift's New Documentation Site Is Now Live"
+author: [heckj]
+category: "Community"
+description: "Swift has a new hosted documentation site at docs.swift.org, bringing together the language guide, the standard library and testing reference, and toolchain documentation, updated at least daily."
+---
+
+New documentation for Swift is live at [docs.swift.org](https://docs.swift.org/latest/documentation/).
+It brings together the Swift Programming Language guide, the reference API for the standard library and testing, and documentation for the toolchain and Swift on each platform.
+Content is updated at least daily from across the [swiftlang](https://github.com/swiftlang/) repositories.
+
+## Where to look
+
+- Latest release (canonical) docs: <https://docs.swift.org/latest/documentation/>
+- Nightly `main` branch docs: <https://docs.swift.org/main/documentation/>
+- The "Docs" menu on [swift.org](https://swift.org) and [docs.swift.org](https://docs.swift.org/) point here too, and old links redirect.
+
+This is a living site, not a finished product.
+We wanted to make it available right away, and we'll keep improving it.
+Documentation for libraries and Swift packages continues to live on the Swift Package Index.
+
+One gap worth noting: Foundation's reference API isn't included yet.
+We're working on open sourcing that content, the same way we did for the Swift standard library.
+
+## A note on versions
+
+`latest` tracks the most recently released branch, and `main` tracks nightly development.
+A `6.4` slug for previously released documentation is coming once 6.4 ships.
+
+## Next steps
+
+There's a lot more behind this launch: nearly two years of work, what's still missing, what's coming next, and ways to get involved.
+For the full story, or if you're inclined to get involved, see [the announcement on the Swift Forums](https://forums.swift.org/t/swifts-new-documentation-site/89192).

--- a/_posts/2026-08-28-swifts-new-documentation-site.md
+++ b/_posts/2026-08-28-swifts-new-documentation-site.md
@@ -22,7 +22,7 @@ We wanted to make it available right away, and we'll keep improving it.
 Documentation for libraries and Swift packages continues to live on the Swift Package Index.
 
 One gap worth noting: Foundation's reference API isn't included yet.
-We're working on open sourcing that content, the same way we did for the Swift standard library.
+Work is underway to open source that content, as has been done for the Swift standard library.
 
 ## A note on versions
 

--- a/_posts/2026-08-28-swifts-new-documentation-site.md
+++ b/_posts/2026-08-28-swifts-new-documentation-site.md
@@ -10,7 +10,7 @@ description: "Swift has a new hosted documentation site at docs.swift.org, bring
 
 A reorganized and refreshed Swift documentation site is live at [docs.swift.org](https://docs.swift.org/latest/documentation/).
 It brings together the Swift Programming Language guide, the reference API for the standard library and testing, and documentation for the toolchain and Swift on each platform.
-Content is updated at least daily from across the [swiftlang](https://github.com/swiftlang/) repositories.
+The site is updated at least daily with any documentation changes across [swiftlang](https://github.com/swiftlang/) repositories.
 
 ## Where to look
 

--- a/_posts/2026-08-28-swifts-new-documentation-site.md
+++ b/_posts/2026-08-28-swifts-new-documentation-site.md
@@ -8,7 +8,7 @@ category: "Community"
 description: "Swift has a new hosted documentation site at docs.swift.org, bringing together the language guide, the standard library and testing reference, and toolchain documentation, updated at least daily."
 ---
 
-New documentation for Swift is live at [docs.swift.org](https://docs.swift.org/latest/documentation/).
+A reorganized and refreshed Swift documentation site is live at [docs.swift.org](https://docs.swift.org/latest/documentation/).
 It brings together the Swift Programming Language guide, the reference API for the standard library and testing, and documentation for the toolchain and Swift on each platform.
 Content is updated at least daily from across the [swiftlang](https://github.com/swiftlang/) repositories.
 

--- a/_posts/2026-08-28-swifts-new-documentation-site.md
+++ b/_posts/2026-08-28-swifts-new-documentation-site.md
@@ -2,10 +2,10 @@
 layout: new-layouts/post
 published: true
 date: 2026-08-28 10:00:00
-title: "Swift's New Documentation Site Is Now Live"
+title: "A New Home For Swift Documentation Site Is Now Live"
 author: [heckj]
 category: "Community"
-description: "Swift has a new hosted documentation site at docs.swift.org, bringing together the language guide, the standard library and testing reference, and toolchain documentation, updated at least daily."
+description: "Swift's documentation is now consolidated at docs.swift.org. The site brings together the language guide, standard library and testing references, and toolchain docs, built with DocC and updated at least daily."
 ---
 
 A reorganized and refreshed Swift documentation site is live at [docs.swift.org](https://docs.swift.org/latest/documentation/).
@@ -14,20 +14,21 @@ The site is updated at least daily with any documentation changes across [swiftl
 
 ## Where to look
 
-- Latest release (canonical) docs: <https://docs.swift.org/latest/documentation/>
+- Latest release docs: <https://docs.swift.org/latest/documentation/>
 - Nightly `main` branch docs: <https://docs.swift.org/main/documentation/>
 
+The URL with `latest` will track the most recently released branch, to make this initial setup easier, it's currently built from the 6.4.x release branch. 
+Going forward, the URL with `latest` is the stable URL to find the latest release docs.
+The URL with `main` tracks nightly development, and a URL `6.4` is coming after the 6.4 release.
+
+## Evolving content
+
 This is a living site, not a finished product.
-We wanted to make it available right away, and we'll keep improving it.
+We wanted to make it available right away, we'll keep improving it, and it's open to contribution.
 Documentation for libraries and Swift packages continues to live on the Swift Package Index.
 
-One gap worth noting: Foundation's reference API isn't included yet.
+One gap worth noting: Foundation's reference API isn't yet included.
 Work is underway to open source that content, as has been done for the Swift standard library.
-
-## A note on versions
-
-`latest` tracks the most recently released branch, and `main` tracks nightly development.
-A `6.4` slug for previously released documentation is coming once 6.4 ships.
 
 ## Next steps
 

--- a/_posts/2026-08-28-swifts-new-documentation-site.md
+++ b/_posts/2026-08-28-swifts-new-documentation-site.md
@@ -2,7 +2,7 @@
 layout: new-layouts/post
 published: true
 date: 2026-08-28 10:00:00
-title: "A New Home For Swift Documentation Site Is Now Live"
+title: "A New Home for the Swift Documentation Site"
 author: [heckj]
 category: "Community"
 description: "Swift's documentation is now consolidated at docs.swift.org. The site brings together the language guide, standard library and testing references, and toolchain docs, built with DocC and updated at least daily."
@@ -17,14 +17,14 @@ The site is updated at least daily with any documentation changes across [swiftl
 - Latest release docs: <https://docs.swift.org/latest/documentation/>
 - Nightly `main` branch docs: <https://docs.swift.org/main/documentation/>
 
-The URL with `latest` will track the most recently released branch, to make this initial setup easier, it's currently built from the 6.4.x release branch. 
+The URL with `latest` will track the most recently released branch. To make this initial setup easier, it's currently built from the 6.4.x release branch.
 Going forward, the URL with `latest` is the stable URL to find the latest release docs.
-The URL with `main` tracks nightly development, and a URL `6.4` is coming after the 6.4 release.
+The URL with `main` tracks nightly development, and a URL with `6.4` is coming after the 6.4 release.
 
 ## Evolving content
 
 This is a living site, not a finished product.
-We wanted to make it available right away, we'll keep improving it, and it's open to contribution.
+We wanted to make it available right away, and we'll keep improving it — it's also open to contribution.
 Documentation for libraries and Swift packages continues to live on the Swift Package Index.
 
 One gap worth noting: Foundation's reference API isn't yet included.
@@ -33,5 +33,5 @@ Work is underway to open source that content, as has been done for the Swift sta
 ## Next steps
 
 There's a lot more behind this launch: nearly two years of work, what's still missing, what's coming next, and ways to get involved.
-The coordination and some of the content is hosted at [swiftlang/docs](https://github.com/swiftlang/docs), with much of the content coming from repositories in the [swiftlang](https://github.com/swiftlang).
+The overall structure and some of the content are hosted at [swiftlang/docs](https://github.com/swiftlang/docs), with much of the content coming from repositories in the [swiftlang](https://github.com/swiftlang).
 For the full story, or if you're inclined to get involved, see [the announcement on the Swift Forums](https://forums.swift.org/t/swifts-new-documentation-site/89192).

--- a/_posts/2026-08-28-swifts-new-documentation-site.md
+++ b/_posts/2026-08-28-swifts-new-documentation-site.md
@@ -16,7 +16,6 @@ Content is updated at least daily from across the [swiftlang](https://github.com
 
 - Latest release (canonical) docs: <https://docs.swift.org/latest/documentation/>
 - Nightly `main` branch docs: <https://docs.swift.org/main/documentation/>
-- The "Docs" menu on [swift.org](https://swift.org) and [docs.swift.org](https://docs.swift.org/) point here too, and old links redirect.
 
 This is a living site, not a finished product.
 We wanted to make it available right away, and we'll keep improving it.
@@ -33,4 +32,5 @@ A `6.4` slug for previously released documentation is coming once 6.4 ships.
 ## Next steps
 
 There's a lot more behind this launch: nearly two years of work, what's still missing, what's coming next, and ways to get involved.
+The coordination and some of the content is hosted at [swiftlang/docs](https://github.com/swiftlang/docs), with much of the content coming from repositories in the [swiftlang](https://github.com/swiftlang).
 For the full story, or if you're inclined to get involved, see [the announcement on the Swift Forums](https://forums.swift.org/t/swifts-new-documentation-site/89192).


### PR DESCRIPTION
Blog post announcing the new docs site, with a link to further detail on the Swift forums

### Motivation:

Ideally, to head off the possible criticism that this site isn't complete, and to make it clear that the docs are an open part of the community process, and will advance.

